### PR TITLE
Retrieve waypoints in JSON, possibility to add a custom marker

### DIFF
--- a/WP-GPX-Maps.js
+++ b/WP-GPX-Maps.js
@@ -2,7 +2,7 @@
 Plugin Name: WP-GPX-Maps
 Plugin URI: http://www.devfarm.it/
 Description: Draws a gpx track with altitude graph
-Version: 1.3.3
+Version: 1.3.8
 Author: Bastianon Massimo
 Author URI: http://www.pedemontanadelgrappa.it/
 */
@@ -347,7 +347,7 @@ Author URI: http://www.pedemontanadelgrappa.it/
 		
 		
 		// Print WayPoints
-		if (waypoints != '')
+		if (!jQuery.isEmptyObject(waypoints))
 		{
 
 			var image = new google.maps.MarkerImage('http://maps.google.com/mapfiles/ms/micons/flag.png',
@@ -365,15 +365,26 @@ Author URI: http://www.pedemontanadelgrappa.it/
 			{
 				image = new google.maps.MarkerImage(waypointIcon);
 				shadow = '';
-			}		
-			
-			for (i=0; i < waypoints.length; i++) 
-			{
-				var lat= waypoints[i][0];
-				var lon= waypoints[i][1];
-				addWayPoint(map, image, shadow, lat, lon, waypoints[i][2], waypoints[i][3]);
-				bounds.extend(new google.maps.LatLng(lat, lon));
 			}
+			
+			jQuery.each(waypoints, function(i, wpt) {
+				
+				var lat= wpt.lat;
+				var lon= wpt.lon;
+				var sym= wpt.sym;
+				var typ= wpt.type;
+				var wim= image;
+				var wsh= shadow;
+
+				if (wpt.img) {
+					wim = new google.maps.MarkerImage(wpt.img);
+					wsh = '';
+				}
+
+				addWayPoint(map, wim, wsh, lat, lon, wpt.name, wpt.desc);
+				bounds.extend(new google.maps.LatLng(lat, lon));
+				
+			});
 		}
 		
 		// Print Images
@@ -1183,31 +1194,35 @@ Author URI: http://www.pedemontanadelgrappa.it/
 							  zIndex: 5
 						  });
 						  
-		google.maps.event.addListener(m, 'mouseover', function() {
+		google.maps.event.addListener(m, 'click', function() {
 			if (infowindow)
 			{
 				infowindow.close(); 		
 			}
 			var cnt = '';	
+			
 			if (title=='')
 			{
-				cnt = "<div style='text-align:center;'>" + unescape(descr) + "</div>";
+				cnt = "<div>" + unescape(descr) + "</div>";
 			}
 			else
 			{
-				cnt = "<div style='font-size:0.8em; text-align:center;'><b>" + title + "</b><br />" + unescape(descr) + "</div>";
+				cnt = "<div><b>" + title + "</b><br />" + unescape(descr) + "</div>";
 			}
+			
+			cnt += "<br /><p><a href='https://maps.google.com?daddr=" + lat + "," + lon + "' target='_blank'>Itin&eacute;raire</a></p>";
+			
 			infowindow = new google.maps.InfoWindow({ content: cnt});
 			infowindow.open(map,m);
 		});	
-			
+		/*
 		google.maps.event.addListener(m, "mouseout", function () {
 			if (infowindow)
 			{
 				infowindow.close();
 			}
 		});
-		
+		*/
 	}
 
 	function getItemFromArray(arr,index)

--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -3,7 +3,7 @@
 Plugin Name: WP-GPX-Maps
 Plugin URI: http://www.devfarm.it/
 Description: Draws a GPX track with altitude chart
-Version: 1.3.7
+Version: 1.3.8
 Author: Bastianon Massimo
 Author URI: http://www.pedemontanadelgrappa.it/
 */
@@ -51,7 +51,7 @@ function enqueue_WP_GPX_Maps_scripts()
 	wp_enqueue_script( 'jquery' );
     wp_enqueue_script( 'googlemaps', '//maps.googleapis.com/maps/api/js?sensor=false', null, null);
     wp_enqueue_script( 'highcharts', "//code.highcharts.com/3.0.10/highcharts.js", array('jquery'), "3.0.10", true);
-    wp_enqueue_script( 'WP-GPX-Maps', plugins_url('/WP-GPX-Maps.js', __FILE__), array('jquery','googlemaps','highcharts'), "1.3.5");
+    wp_enqueue_script( 'WP-GPX-Maps', plugins_url('/WP-GPX-Maps.js', __FILE__), array('jquery','googlemaps','highcharts'), "1.3.8");
 }
 
 function print_WP_GPX_Maps_styles()
@@ -67,20 +67,28 @@ function print_WP_GPX_Maps_styles()
 	.wpgpxmaps_summary .summarylabel { }
 	.wpgpxmaps_summary .summaryvalue { font-weight: bold; }
 	.wpgpxmaps .report { line-height:120%; }
-	.wpgpxmaps .gmnoprint div:first-child { height: 20px; }	
+	.wpgpxmaps .gmnoprint div:first-child {  }	
 	.wpgpxmaps .wpgpxmaps_osm_footer {
 		position: absolute;
 		left: 0;
 		right: 0;
 		bottom: 0;
 		width: 100%;
-		height: 25px;
+		height: 13px;
 		margin: 0;
-		padding: 6px;
 		z-index: 999;
 		background: WHITE;
 		font-size: 12px;
 	}
+	
+	.wpgpxmaps .wpgpxmaps_osm_footer span {
+		background: WHITE;
+		padding: 0 6px 6px 6px;
+		vertical-align: baseline;
+		position: absolute;
+		bottom: 0;
+	}	
+	
 </style>
 <?php
 }
@@ -503,12 +511,16 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		}
 
 		$avg_speed = convertSpeed($avg_speed,$uomspeed,true);
-						
+		
+		$waypoints = '[]';
 		if ($showW == true) {
 			$wpoints = getWayPoints($gpx);
+			/*
 			foreach ($wpoints as $p) {
 				$waypoints .= '['.number_format ( (float)$p[0] , 7 , '.' , '' ).','.number_format ( (float)$p[1] , 7 , '.' , '' ).',\''.unescape($p[4]).'\',\''.unescape($p[5]).'\',\''.unescape($p[7]).'\'],';
 			}
+			*/
+			$waypoints = json_encode($wpoints);
 		}
 
 		if ($showEle == "false")
@@ -614,7 +626,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		<div id="wpgpxmaps_'.$r.'" class="wpgpxmaps">
 			<div id="map_'.$r.'_cont" style="width:'.$w.'; height:'.$mh.';position:relative" >
 				<div id="map_'.$r.'" style="width:'.$w.'; height:'.$mh.'"></div>
-				<div id="wpgpxmaps_'.$r.'_osm_footer" class="wpgpxmaps_osm_footer" style="display:none;">&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</div>			
+				<div id="wpgpxmaps_'.$r.'_osm_footer" class="wpgpxmaps_osm_footer" style="display:none;"><span> &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</span></div>			
 			</div>
 			<div id="hchart_'.$r.'" class="plot" style="width:'.$w.'; height:'.$gh.'"></div>
 			<div id="ngimages_'.$r.'" class="ngimages" style="display:none">'.$ngimgs_data.'</div>
@@ -632,7 +644,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 							graphAtemp  : ['.($hideGraph ? '' : $points_graph_atemp).'],
 							graphCad    : ['.($hideGraph ? '' : $points_graph_cad).'],
 							graphGrade  : ['.($hideGraph ? '' : $points_graph_grade).'],
-							waypoints   : ['.$waypoints.'],
+							waypoints   : '.$waypoints.',
 							unit        : "'.$uom.'",
 							unitspeed   : "'.$uomspeed.'",
 							color1      : ['.$colors_map.'],

--- a/wp-gpx-maps_utils.php
+++ b/wp-gpx-maps_utils.php
@@ -584,21 +584,41 @@
 			$gpx->registerXPathNamespace('10', 'http://www.topografix.com/GPX/1/0'); 
 			$gpx->registerXPathNamespace('11', 'http://www.topografix.com/GPX/1/1'); 
 			$nodes = $gpx->xpath('//wpt | //10:wpt | //11:wpt');
+			global $wpdb;
 			
 			if ( count($nodes) > 0 )	
 			{
 				// normal case
 				foreach($nodes as $wpt)
 				{
-					$lat = $wpt['lat'];
-					$lon = $wpt['lon'];
-					$ele = $wpt->ele;
-					$time = $wpt->time;
-					$name = $wpt->name;
-					$desc = $wpt->desc;
-					$sym = $wpt->sym;
-					$type = $wpt->type;
-					array_push($points, array((float)$lat,(float)$lon,(float)$ele,$time,$name,$desc,$sym,$type));
+					$lat  = $wpt['lat'];
+					$lon  = $wpt['lon'];
+					$ele  = (string) $wpt->ele;
+					$time = (string) $wpt->time;
+					$name = (string) $wpt->name;
+					$desc = (string) $wpt->desc;
+					$sym  = (string) $wpt->sym;
+					$type = (string) $wpt->type;
+					$img  = '';
+					
+					$img_name = 'map-marker-' . $sym;
+					$query = "SELECT ID FROM {$wpdb->prefix}posts WHERE post_name LIKE '{$img_name}' AND post_type LIKE 'attachment'";
+					$img_id = $wpdb->get_var($query);
+					if (!is_null($img_id)) {
+						$img = wp_get_attachment_url($img_id);
+					}
+					
+					array_push($points, array(
+						"lat"  => (float)$lat,
+						"lon"  => (float)$lon,
+						"ele"  => (float)$ele,
+						"time" => $time,
+						"name" => $name,
+						"desc" => $desc,
+						"sym"  => $sym,
+						"type" => $type,
+						"img"  => $img
+					));
 				}
 			}
 		}


### PR DESCRIPTION
I have made a small enhancement in your cool WP-GPX-Plugin : the possibility to have some custom markers for the waypoints.

To achieve this, in **wp-gpx-maps_utils.php** (line 594) I retrieve the 'sym' element from the gpx file and then wuery the Wordpress media for an attachment with this name. After that, just writing the waypoint as a map with the correct image path.

In **wp-gpx-maps.php**, just encode the waypoints as a Json object (much easier to use it in jQuery).

In **WP-GPX-Maps.js**, adapted the code to use the symbol image. I have also changed the behaviour to show the info window from "mousehover" to "click".

Thanks again for the amazing work !
