### PR TITLE
Fix for xml direct download

### DIFF
--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -728,7 +728,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 			$dummy = ( defined('WP_SITEURL') ) ? WP_SITEURL : get_bloginfo('url');
 			$gpxurl = $dummy.$gpxurl;
 		}		
-		$output.="<a href='$gpxurl' target='_new'>".__("Download", "wp-gpx-maps")."</a>";
+		$output.="<a href='$gpxurl' target='_new' download>".__("Download", "wp-gpx-maps")."</a>";
 	}
 
 	return $output;


### PR DESCRIPTION
Enables a user to directly download a gpx file instead opening it in a browser tab as an xml plain file.
