### PR TITLE
Allow authors to upload GPS tracks

### DIFF
--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -40,8 +40,15 @@ function WP_GPX_Maps_action_links($links, $file) {
  
     // check to make sure we are on the correct plugin
     if ($file == $this_plugin) {
-        // the anchor tag and href to the URL we want. For a "Settings" link, this needs to be the url of your settings page
-        $settings_link = '<a href="' . get_bloginfo('wpurl') . '/wp-admin/options-general.php?page=WP-GPX-Maps">Settings</a>';
+        // the anchor tag and href to the URL we want. For a "Settings"
+        // link, this needs to be the url of your settings page. Authors
+        // access tracks via the admin page.
+        if ( current_user_can('manage_options') ) {
+            $menu_root = "options-general.php";
+        } else if ( current_user_can('publish_posts') ) {
+            $menu_root = "admin.php";
+        }
+        $settings_link = '<a href="' . get_bloginfo('wpurl') . '/wp-admin/' . $menu_root . '?page=WP-GPX-Maps">Settings</a>';
         // add the link to the list
         array_unshift($links, $settings_link);
     }

--- a/wp-gpx-maps_admin_tracks.php
+++ b/wp-gpx-maps_admin_tracks.php
@@ -3,12 +3,17 @@
 	if ( !(is_admin()) )
 		return;
 	
-	$is_admin = current_user_can( 'manage_options' );
+	$is_admin = current_user_can( 'publish_posts' );
 	
 	if ( $is_admin != 1 )
 		return;
 	
 	$gpxRegEx = '/.gpx$/i';
+        if ( current_user_can('manage_options') ){
+            $menu_root = "options-general.php";
+        } else if ( current_user_can('publish_posts') ){
+            $menu_root = "admin.php";
+        }
 
 	if ( isset($_POST['clearcache']) )
 	{
@@ -29,7 +34,8 @@
 	?>
 
 		<div class="tablenav top">
-			<form enctype="multipart/form-data" method="POST" style="float:left; margin:5px 20px 0 0" action="/wp-admin/options-general.php?page=WP-GPX-Maps">
+<?php
+            echo '<form enctype="multipart/form-data" method="POST" style="float:left; margin:5px 20px 0 0" action="' . get_bloginfo('wpurl') . '/wp-admin/' . $menu_root . '?page=WP-GPX-Maps">'; ?>
 				Choose a file to upload: <input name="uploadedfile[]" type="file" onchange="submitgpx(this);" multiple />
 				<?php
 					if ( isset($_FILES['uploadedfile']) )									


### PR DESCRIPTION
This change lets authors upload GPS tracks, but not edit the global settings. I am open to suggestions for how to implement this better. Also, I saw some people in the forums requesting editor permissions to upload GPS tracks. I wasn't sure whether that was generally desired or not, so I didn't implement it.

Issues this fixes
* `wp-gpx-maps_admin.php` registers an option for users with 'manage_options' capabilities, but registers a menu page for users with only 'publish_posts' capability. Because this, the URL for the WP-GPX pages is different for the different users. 
* Despite `wp-gpx-maps_admin.php` registering the menu page for authors, the first thing the tracks tab (`wp-gpx-maps_admin_tracks.php`) did was to exit if you don't have 'manage_options' capabilities.
