### PR TITLE
made plugin backend translatable

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: maps, gpx, gps, graph, chart, leaflet, track, garmin, image, nextgen-gallery, nextgen, exif, OpenStreetMap, OpenCycleMap, Hike&Bike, heart rate, heartrate, cadence
 Requires at least: 2.0.0
 Tested up to: 4.9.8
-Stable tag: 1.6.06
+Stable tag: 1.6.07
 
 Draws a gpx track with altitude graph. You can also display your nextgen gallery images in the map.
 
@@ -17,7 +17,7 @@ Now on github: https://github.com/devfarm-it/wp-gpx-maps
 On github you can contribuite easly with your code
 
 
-Fully configurable: 
+Fully configurable:
 - Custom colors
 - Custom icons
 - Multiple language support
@@ -32,8 +32,8 @@ Supported charts:
 
 NextGen Gallery Integration:
 
-Display your NextGen Gallery images inside the map! 
-Even if you don't have a gps camera, this plugin can retrive the image position starting from the image date and you gpx file. 
+Display your NextGen Gallery images inside the map!
+Even if you don't have a gps camera, this plugin can retrive the image position starting from the image date and you gpx file.
 
 Post Attachments Integration:
 
@@ -126,17 +126,17 @@ The attributes are:
 1. nggalleries: NextGen Gallery id or a list of Galleries id separated by a comma
 1. ngimages: NextGen Image id or a list of Images id separated by a comma
 1. dtoffset: the difference (in seconds) between your gpx tool date and your camera date
-1. zoomonscrollwheel: zoom on map when mouse scroll wheel 
-1. download: Allow users to download your GPX file 
-1. skipcache: Do not use cache. If TRUE might be very slow (default is FALSE) 
-1. summary: Print summary details of your GPX (default is FALSE) 
-1. summarytotlen: Print Total distance in summary table (default is FALSE) 
-1. summarymaxele: Print Max Elevation in summary table (default is FALSE) 
-1. summaryminele: Print Min Elevation in summary table (default is FALSE) 
-1. summaryeleup: Print Total climbing in summary table (default is FALSE) 
-1. summaryeledown: Print Total descent in summary table (default is FALSE) 
-1. summaryavgspeed: Print Average Speed in summary table (default is FALSE) 
-1. summarytotaltime: Print Total time in summary table (default is FALSE) 
+1. zoomonscrollwheel: zoom on map when mouse scroll wheel
+1. download: Allow users to download your GPX file
+1. skipcache: Do not use cache. If TRUE might be very slow (default is FALSE)
+1. summary: Print summary details of your GPX (default is FALSE)
+1. summarytotlen: Print Total distance in summary table (default is FALSE)
+1. summarymaxele: Print Max Elevation in summary table (default is FALSE)
+1. summaryminele: Print Min Elevation in summary table (default is FALSE)
+1. summaryeleup: Print Total climbing in summary table (default is FALSE)
+1. summaryeledown: Print Total descent in summary table (default is FALSE)
+1. summaryavgspeed: Print Average Speed in summary table (default is FALSE)
+1. summarytotaltime: Print Total time in summary table (default is FALSE)
 
 = What happening if I've a very large gpx? =
 This plugin will print a small amout of points to speedup javascript and pageload.
@@ -153,14 +153,16 @@ Yes!
 1. Altitude & Speed & Hearth rate
 
 == Changelog ==
-= 1.6.06 = 
-* Added average values under the graph
-= 1.6.04 = 
+= 1.6.07 =
+* resolve admin error
+= 1.6.06 =
+* Added average values under the graph (thanks to cyclinggeorgian)
+= 1.6.04 =
 * NGG gallery is working
 * Getting HR, Cad and Temp working again (thanks to cyclinggeorgian)
-* Fix javascript errors 
+* Fix javascript errors
 * Fix multiple traks gpx
-= 1.6.03 = 
+= 1.6.03 =
 * Fix syntax error causing graph not to display (thanks to nickstabler)
 = 1.6.02 =
 * Resolved errors with start and end icons
@@ -186,8 +188,8 @@ Yes!
 = 1.5.00 =
 * replaced highcharts with chartjs. This is a forced choice due highcharts license issue, view:  https://devfarm.it/wordpress-plugin/wordpress-plugin-directory-notice-wp-gpx-maps-temporarily-disabled/
 = 1.3.16 =
-* Added Norwegian nb_NO translation (thanks to thordivel) 
-* Added Japanese ja_JP translation (thanks to dentos) 
+* Added Norwegian nb_NO translation (thanks to thordivel)
+* Added Japanese ja_JP translation (thanks to dentos)
 = 1.3.15 =
 * Switched to HTTPS where possible (thanks to delitestudio)
 = 1.3.14 =
@@ -243,7 +245,7 @@ Yes!
 = 1.2.2 =
 * Smaller map type selector
 * New map: MapToolKit - Terrain
-* Fix: Google maps exception for NextGen Gallery 
+* Fix: Google maps exception for NextGen Gallery
 = 1.2.1 =
 * Fix: NextGen Gallery 1.9 compatibility
 = 1.2.0 =
@@ -265,11 +267,11 @@ Yes!
 * qTranslate compatible
 = 1.1.41 =
 * Added Polish translation, thanks to Sebastian
-* Fix: Spanish translation 
+* Fix: Spanish translation
 * Minor javascript improvement
 = 1.1.40 =
 * Improved italian translation
-* Added grade chart (beta) 
+* Added grade chart (beta)
 = 1.1.39 =
 * Added French translation, thanks to Hervé
 * Added Nautical Miles per Hour (Knots) unit of measure
@@ -282,7 +284,7 @@ Yes!
 = 1.1.35 =
 * Fix: In the post list, sometime, the maps was not displaying correctly ( the php rand() function was not working?? )
 * Various improvements for multi track gpx. Thanks to GPSracks.tv
-* Summary table is now avaiable even without chart. Thanks to David 
+* Summary table is now avaiable even without chart. Thanks to David
 = 1.1.34 =
 * 2 decimals for unit of measure min/km and min/mi
 * translation file updated (a couple of phrases added)
@@ -290,7 +292,7 @@ Yes!
 * nggallery integration: division by zero fixed
 = 1.1.33 =
 * Decimals reducted to 1 for unit of measure min/km and min/mi
-* map zoom and center position is working with waypoints only files 
+* map zoom and center position is working with waypoints only files
 * automatic scale works again (thanks to MArkus)
 = 1.1.32 =
 * You can exclude cache (slower and not recommended)
@@ -326,12 +328,12 @@ Yes!
 * upgrade to google maps 3.9
 = 1.1.20 =
 * google maps images fixed in <a href="http://wordpress.org/extend/themes/yoko">Yoko theme</a>
-= 1.1.19 = 
+= 1.1.19 =
 * include jQuery if needed
-= 1.1.17 = 
+= 1.1.17 =
 * Remove zero values from cadence and heart rate charts
 * nextgen gallery improvement
-= 1.1.16 = 
+= 1.1.16 =
 * Cadence chart (where available)
 * minor bug fixes
 = 1.1.15 =
@@ -341,7 +343,7 @@ Yes!
 * added css to avoid map bars display issue
 = 1.1.13 =
 * added new types of maps: Open Street Map, Open Cycle Map, Hike & Bike.
-* fixed nextgen gallery caching problem 
+* fixed nextgen gallery caching problem
 = 1.1.12 =
 * nextgen gallery display bug fixes
 

--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-GPX-Maps
  * Plugin URI: http://www.devfarm.it/
  * Description: Draws a GPX track with altitude chart
- * Version: 1.6.06
+ * Version: 1.6.07
  * Author: Bastianon Massimo
  * Author URI: http://www.devfarm.it/
  * Text Domain: wp-gpx-maps
@@ -17,27 +17,27 @@ include 'wp-gpx-maps_admin.php';
 
 add_shortcode('sgpx','handle_WP_GPX_Maps_Shortcodes');
 add_shortcode('sgpxf','handle_WP_GPX_Maps_folder_Shortcodes');
-register_activation_hook(__FILE__,'WP_GPX_Maps_install'); 
+register_activation_hook(__FILE__,'WP_GPX_Maps_install');
 register_deactivation_hook( __FILE__, 'WP_GPX_Maps_remove');
 add_filter('plugin_action_links', 'WP_GPX_Maps_action_links', 10, 2);
 add_action('wp_print_styles', 'print_WP_GPX_Maps_styles' );
 add_action('wp_enqueue_scripts', 'enqueue_WP_GPX_Maps_scripts');
-add_action('admin_enqueue_scripts', 'enqueue_WP_GPX_Maps_scripts_admin' ); 
+add_action('admin_enqueue_scripts', 'enqueue_WP_GPX_Maps_scripts_admin' );
 add_action('plugins_loaded' ,'WP_GPX_Maps_lang_init');
 
 function WP_GPX_Maps_lang_init() {
-   if (function_exists('load_plugin_textdomain')) {
+   if (function_exists( 'load_plugin_textdomain' )) {
       load_plugin_textdomain('wp-gpx-maps', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
    }
 }
 
 function WP_GPX_Maps_action_links($links, $file) {
     static $this_plugin;
- 
+
     if (!$this_plugin) {
         $this_plugin = plugin_basename(__FILE__);
     }
- 
+
     // check to make sure we are on the correct plugin
     if ($file == $this_plugin) {
         // the anchor tag and href to the URL we want. For a "Settings"
@@ -48,32 +48,32 @@ function WP_GPX_Maps_action_links($links, $file) {
         } else if ( current_user_can('publish_posts') ) {
             $menu_root = "admin.php";
         }
-        $settings_link = '<a href="' . get_bloginfo('wpurl') . '/wp-admin/' . $menu_root . '?page=WP-GPX-Maps">Settings</a>';
+		$settings_link = '<a href="' . get_bloginfo('wpurl') . '/wp-admin/' . $menu_root . '?page=WP-GPX-Maps">' . __( 'Settings', 'wp-gpx-maps' ) . '</a>';
         // add the link to the list
         array_unshift($links, $settings_link);
     }
- 
+
     return $links;
 }
 
 function enqueue_WP_GPX_Maps_scripts_admin($hook)
-{	
-	if ( strpos($hook, 'WP-GPX-Maps') !== false ) {		
+{
+	if ( strpos($hook, 'WP-GPX-Maps') !== false ) {
 		wp_register_script('mColorPicker', plugins_url( '/js/mColorPicker_min.js', __FILE__ ), array(), "1.0 r39" );
-		wp_enqueue_script('mColorPicker');			
+		wp_enqueue_script('mColorPicker');
 		wp_register_script('bootstrap-table', plugins_url( '/js/bootstrap-table.min.js', __FILE__ ), array(), "1.11.1" );
 		wp_enqueue_script('bootstrap-table');
 		wp_register_style('bootstrap-table', plugins_url( '/css/bootstrap-table.min.css', __FILE__ ), array(), "1.11.1" );
-		wp_enqueue_style('bootstrap-table');		
+		wp_enqueue_style('bootstrap-table');
 	}
 }
 
-function enqueue_WP_GPX_Maps_scripts() {		
+function enqueue_WP_GPX_Maps_scripts() {
 
 	/* leaflet */
 	wp_register_style( 'leaflet', plugins_url( '/ThirdParties/Leaflet_1.3.1/leaflet.css', __FILE__ ), array(), "1.3.1" );
 	wp_enqueue_style( 'leaflet' );	wp_register_style( 'leaflet.markercluster', plugins_url( '/ThirdParties/Leaflet.markercluster-1.4.1/MarkerCluster.css', __FILE__ ), array(), "0" );	wp_enqueue_style( 'leaflet.markercluster' );		wp_register_style( 'leaflet.Photo', plugins_url( '/ThirdParties/Leaflet.Photo/Leaflet.Photo.css', __FILE__ ), array(), "0" );	wp_enqueue_style( 'leaflet.Photo' );
-	
+
 	wp_register_style( 'leaflet.fullscreen', plugins_url( '/ThirdParties/leaflet.fullscreen-1.1.4/Control.FullScreen.css', __FILE__ ), array(), "1.3.1" );
 	wp_enqueue_style( 'leaflet.fullscreen' );
 
@@ -82,15 +82,17 @@ function enqueue_WP_GPX_Maps_scripts() {
 
 	/* chartjs */
 	wp_register_script('chartjs', plugins_url( '/js/Chart.min.js', __FILE__ ), array(), "2.7.2" );
-	
+
 	wp_register_script('WP-GPX-Maps', plugins_url( '/js/WP-GPX-Maps.js', __FILE__ ), array('jquery','leaflet','chartjs'), "1.6.04" );
 
-	wp_enqueue_script('leaflet');	wp_enqueue_script('leaflet.markercluster');	wp_enqueue_script('leaflet.Photo');
+	wp_enqueue_script('leaflet');
+	wp_enqueue_script('leaflet.markercluster');
+	wp_enqueue_script('leaflet.Photo');
 	wp_enqueue_script('leaflet.fullscreen');
 	wp_enqueue_script('jquery');
-	wp_enqueue_script('chartjs'); 	
+	wp_enqueue_script('chartjs');
     wp_enqueue_script('WP-GPX-Maps');
-	
+
 }
 
 function print_WP_GPX_Maps_styles() {
@@ -106,7 +108,7 @@ function print_WP_GPX_Maps_styles() {
 	.wpgpxmaps_summary .summarylabel { }
 	.wpgpxmaps_summary .summaryvalue { font-weight: bold; }
 	.wpgpxmaps .report { line-height:120%; }
-	.wpgpxmaps .gmnoprint div:first-child {  }	
+	.wpgpxmaps .gmnoprint div:first-child {  }
 	.wpgpxmaps .wpgpxmaps_osm_footer {
 		position: absolute;
 		left: 0;
@@ -119,15 +121,15 @@ function print_WP_GPX_Maps_styles() {
 		background: WHITE;
 		font-size: 12px;
 	}
-	
+
 	.wpgpxmaps .wpgpxmaps_osm_footer span {
 		background: WHITE;
 		padding: 0 6px 6px 6px;
 		vertical-align: baseline;
 		position: absolute;
 		bottom: 0;
-	}	
-	
+	}
+
 </style>
 <?php
 }
@@ -153,35 +155,35 @@ function handle_WP_GPX_Maps_folder_Shortcodes($attr, $content='') {
 
 	$folder =             wpgpxmaps_findValue($attr, "folder",             "",                                 "");
 	$pointsoffset =       wpgpxmaps_findValue($attr, "pointsoffset",       "wpgpxmaps_pointsoffset",     		 10);
-	$distanceType =       wpgpxmaps_findValue($attr, "distanceType",        "wpgpxmaps_distance_type", 		 0);
+	$distanceType =       wpgpxmaps_findValue($attr, "distanceType",       "wpgpxmaps_distance_type", 		 0);
 	$donotreducegpx =     wpgpxmaps_findValue($attr, "donotreducegpx",     "wpgpxmaps_donotreducegpx", 		 false);
 	$uom =                wpgpxmaps_findValue($attr, "uom",                "wpgpxmaps_unit_of_measure",        "0");
-	
+
 	// fix folder path
-	$sitePath = wp_gpx_maps_sitePath();	
+	$sitePath = wp_gpx_maps_sitePath();
 	$folder = trim($folder);
 	$folder = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $folder);
-	$folder = $sitePath . $folder;	
-	
+	$folder = $sitePath . $folder;
+
 	$files = scandir($folder);
-	
+
 	foreach($files as $file) {
-	
+
 		if (strtolower(substr($file, - 4)) == ".gpx" ) {
-		
+
 			$gpx = $folder . DIRECTORY_SEPARATOR . $file;
 			$points = wpgpxmaps_getPoints($gpx, $pointsoffset, $donotreducegpx, $distanceType);
-				
+
 			$points_maps = '';
 			$points_graph_dist = '';
 			$points_graph_ele = '';
-				
+
 			if (is_array ($points_x_lat))
 			foreach(array_keys($points_x_lat) as $i) {
-				
+
 				$_lat = (float)$points_x_lat[$i];
 				$_lon = (float)$points_x_lon[$i];
-				
+
 				if ( $_lat == 0 && $_lon == 0 )
 				{
 					$points_maps .= 'null,';
@@ -190,14 +192,14 @@ function handle_WP_GPX_Maps_folder_Shortcodes($attr, $content='') {
 
 				}
 				else {
-					$points_maps .= '['.number_format((float)$points_x_lat[$i], 7 , '.' , '' ).','.number_format((float)$points_x_lon[$i], 7 , '.' , '' ).'],';	
+					$points_maps .= '['.number_format((float)$points_x_lat[$i], 7 , '.' , '' ).','.number_format((float)$points_x_lon[$i], 7 , '.' , '' ).'],';
 
-					$_ele = (float)$points->ele[$i];	
-					$_dist = (float)$points->dist[$i];	
-					
+					$_ele = (float)$points->ele[$i];
+					$_dist = (float)$points->dist[$i];
+
 					if ($uom == '1')
 					{
-						// Miles and feet			
+						// Miles and feet
 						$_dist *= 0.000621371192;
 						$_ele *= 3.2808399;
 					} else if ($uom == '2')
@@ -218,15 +220,15 @@ function handle_WP_GPX_Maps_folder_Shortcodes($attr, $content='') {
 						$_dist = (float)($_dist / 1000 / 1.852);
 						$_ele *= 3.2808399;
 					}
-					
+
 					$points_graph_dist .= number_format ( $_dist , 2 , '.' , '' ).',';
 					$points_graph_ele .= number_format ( $_ele , 2 , '.' , '' ).',';
-						
+
 				}
-			}	
-			
+			}
+
 			print_r($points);
-		
+
 		}
 	}
 }
@@ -248,7 +250,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 	$showW =              wpgpxmaps_findValue($attr, "waypoints",          "wpgpxmaps_show_waypoint",   		 false);
 	$showEle =            wpgpxmaps_findValue($attr, "showele",            "wpgpxmaps_show_elevation",   		 "true");
 	$showSpeed =          wpgpxmaps_findValue($attr, "showspeed",          "wpgpxmaps_show_speed",      		 false);
-	$showGrade =          wpgpxmaps_findValue($attr, "showgrade",          "wpgpxmaps_show_grade",      		 false);	
+	$showGrade =          wpgpxmaps_findValue($attr, "showgrade",          "wpgpxmaps_show_grade",      		 false);
 	$zoomOnScrollWheel =  wpgpxmaps_findValue($attr, "zoomonscrollwheel",  "wpgpxmaps_zoomonscrollwheel",      false);
 	$donotreducegpx =     wpgpxmaps_findValue($attr, "donotreducegpx",     "wpgpxmaps_donotreducegpx", 		 false);
 	$pointsoffset =       wpgpxmaps_findValue($attr, "pointsoffset",       "wpgpxmaps_pointsoffset",     		 10);
@@ -261,7 +263,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 	$color_graph_atemp =  wpgpxmaps_findValue($attr, "glinecoloratemp",    "wpgpxmaps_graph_line_color_atemp", "#ff77bd");
 	$color_graph_cad =    wpgpxmaps_findValue($attr, "glinecolorcad",      "wpgpxmaps_graph_line_color_cad",   "#beecff");
 	$color_graph_grade =  wpgpxmaps_findValue($attr, "glinecolorgrade",    "wpgpxmaps_graph_line_color_grade",  "#beecff");
-	
+
 	$chartFrom1 =         wpgpxmaps_findValue($attr, "chartfrom1",         "wpgpxmaps_graph_offset_from1",     "");
 	$chartTo1 =           wpgpxmaps_findValue($attr, "chartto1",           "wpgpxmaps_graph_offset_to1",       "");
 	$chartFrom2 =         wpgpxmaps_findValue($attr, "chartfrom2",         "wpgpxmaps_graph_offset_from2", 	 "");
@@ -277,10 +279,10 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 	$download =           wpgpxmaps_findValue($attr, "download",           "wpgpxmaps_download", 		     	 "");
 	$dtoffset =           wpgpxmaps_findValue($attr, "dtoffset",           "wpgpxmaps_dtoffset", 		     	 0);
 	$distanceType =       wpgpxmaps_findValue($attr, "distanceType",       "wpgpxmaps_distance_type", 		 0);
-	
+
 	$skipcache =          wpgpxmaps_findValue($attr, "skipcache",          "wpgpxmaps_skipcache", 	     	 "");
-	
-	$summary =            wpgpxmaps_findValue($attr, "summary",            "wpgpxmaps_summary", 		     	 "");	
+
+	$summary =            wpgpxmaps_findValue($attr, "summary",            "wpgpxmaps_summary", 		     	 "");
 	$p_tot_len =          wpgpxmaps_findValue($attr, "summarytotlen",      "wpgpxmaps_summary_tot_len",      	 false);
 	$p_max_ele =          wpgpxmaps_findValue($attr, "summarymaxele",      "wpgpxmaps_summary_max_ele",      	 false);
 	$p_min_ele =          wpgpxmaps_findValue($attr, "summaryminele",      "wpgpxmaps_summary_min_ele",      	 false);
@@ -291,14 +293,14 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 	$p_avg_hr =           wpgpxmaps_findValue($attr, "summaryavghr",       "wpgpxmaps_summary_avg_hr",      false);
 	$p_avg_temp =         wpgpxmaps_findValue($attr, "summaryavgtemp",     "wpgpxmaps_summary_avg_temp",      false);
 	$p_total_time =       wpgpxmaps_findValue($attr, "summarytotaltime",    "wpgpxmaps_summary_total_time",     false);
-	
+
 	$usegpsposition =     wpgpxmaps_findValue($attr, "usegpsposition",     "wpgpxmaps_usegpsposition",         false);
 	$currentpositioncon = wpgpxmaps_findValue($attr, "currentpositioncon", "wpgpxmaps_currentpositioncon", 	 "");
-	
+
 	$colors_map = "\"".implode("\",\"",(explode(" ",$color_map)))."\"";
-	
+
 	$gpxurl = $gpx;
-		
+
 	// Add file modification time to cache filename to catch new uploads with same file name
 	$mtime = wp_gpx_maps_sitePath() . str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, trim($gpx));
 	if(file_exists($mtime)) {
@@ -309,17 +311,17 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 	$cacheFileName = "$gpx,$mtime,$w,$mh,$mt,$gh,$showEle,$showW,$showHr,$showAtemp,$showCad,$donotreducegpx,$pointsoffset,$showSpeed,$showGrade,$uomspeed,$uom,$distanceType,v1.3.9";
 
 	$cacheFileName = md5($cacheFileName);
-	
+
 	$gpxcache = gpxCacheFolderPath();
-	
+
 	if(!(file_exists($gpxcache) && is_dir($gpxcache)))
 		@mkdir($gpxcache,0755,true);
-	
+
 	$gpxcache.= DIRECTORY_SEPARATOR.$cacheFileName.".tmp";
-	
+
 	// Try to load cache
 	if (file_exists($gpxcache) && !($skipcache == true)) {
-	
+
 		try {
 			$cache_str = file_get_contents($gpxcache);
 			$cache_obj = unserialize($cache_str);
@@ -346,7 +348,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 			$avg_hr = $cache_obj["avg_hr"];
 			$avg_temp = $cache_obj["avg_temp"];
 			$tot_len = $cache_obj["tot_len"];
-			
+
 		} catch (Exception $e) {
 			$points_maps = '';
 			$points_x_time = '';
@@ -373,16 +375,16 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 			$tot_len = 0;
 		}
 	}
-	
+
 	$isGpxUrl = (preg_match('/^(http(s)?\:\/\/)/', trim($gpx)) == 1);
 
 	if ((!isset($points_maps) || $points_maps == '') && $gpx != '')	{
 	//if (true)	{
-	
+
 		$sitePath = wp_gpx_maps_sitePath();
-		
+
 		$gpx = trim($gpx);
-		
+
 		if ($isGpxUrl == true) {
 			$gpx = downloadRemoteFile($gpx);
 		}
@@ -394,9 +396,9 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		if ($gpx == '')	{
 			return "No gpx found";
 		}
-		
+
 		$points = wpgpxmaps_getPoints( $gpx, $pointsoffset, $donotreducegpx, $distanceType);
-		
+
 		$points_maps = '';
 		$points_graph_dist = '';
 		$points_graph_ele = '';
@@ -410,7 +412,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		$points_x_time = $points->dt;
 		$points_x_lat = $points->lat;
 		$points_x_lon = $points->lon;
-		
+
 		$max_ele = $points->maxEle;
 		$min_ele = $points->minEle;
 		$max_time = $points->maxTime;
@@ -422,44 +424,44 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		$avg_hr = $points->avgHr;
 		$avg_temp = $points->avgTemp;
 		$tot_len = $points->totalLength;
-			
+
 		if (is_array ($points_x_lat))
 		foreach(array_keys($points_x_lat) as $i) {
-			
+
 			$_lat = (float)$points_x_lat[$i];
 			$_lon = (float)$points_x_lon[$i];
-			
+
 			if ( $_lat == 0 && $_lon == 0 )
 			{
 				$points_maps .= 'null,';
 				$points_graph_dist .= 'null,';
 				$points_graph_ele .= 'null,';
-					
-				if ($showSpeed == true) 
+
+				if ($showSpeed == true)
 					$points_graph_speed .= 'null,';
 
 				if ($showHr == true)
 					$points_graph_hr .= 'null,';
-					
+
 				if ($showAtemp == true)
 					$points_graph_atemp .= 'null,';
-					
+
 				if ($showCad == true)
 					$points_graph_cad .= 'null,';
-					
+
 				if ($showGrade == true)
 					$points_graph_grade .= 'null,';
-					
+
 			}
 			else {
-				$points_maps .= '['.number_format((float)$points_x_lat[$i], 7 , '.' , '' ).','.number_format((float)$points_x_lon[$i], 7 , '.' , '' ).'],';	
+				$points_maps .= '['.number_format((float)$points_x_lat[$i], 7 , '.' , '' ).','.number_format((float)$points_x_lon[$i], 7 , '.' , '' ).'],';
 
-				$_ele = (float)$points->ele[$i];	
-				$_dist = (float)$points->dist[$i];	
-				
+				$_ele = (float)$points->ele[$i];
+				$_dist = (float)$points->dist[$i];
+
 				if ($uom == '1')
 				{
-					// Miles and feet			
+					// Miles and feet
 					$_dist *= 0.000621371192;
 					$_ele *= 3.2808399;
 				} else if ($uom == '2')
@@ -480,44 +482,44 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 					$_dist = (float)($_dist / 1000 / 1.852);
 					$_ele *= 3.2808399;
 				}
-				
+
 				$points_graph_dist .= number_format ( $_dist , 2 , '.' , '' ).',';
 				$points_graph_ele .= number_format ( $_ele , 2 , '.' , '' ).',';
-					
+
 				if ($showSpeed == true) {
-				
+
 					$_speed = (float)$points->speed[$i];
-					
+
 					$points_graph_speed .= convertSpeed($_speed,$uomspeed).',';
 				}
-				
+
 				if ($showHr == true) {
 					$points_graph_hr .= number_format ( $points->hr[$i] , 2 , '.' , '' ).',';
 				}
-				
+
 				if ($showAtemp == true) {
 					$points_graph_atemp .= number_format ( $points->atemp[$i] , 1 , '.' , '' ).',';
 				}
-				
+
 				if ($showCad == true) {
 					$points_graph_cad .= number_format ( $points->cad[$i] , 2 , '.' , '' ).',';
 				}
-				
+
 				if ($showGrade == true) {
 					$points_graph_grade .= number_format ( $points->grade[$i] , 2 , '.' , '' ).',';
 				}
-				
+
 			}
-		}	
+		}
 
 		if ($uom == '1') {
-			// Miles and feet			
+			// Miles and feet
 			$tot_len = round($tot_len * 0.000621371192, 2)." mi";
 			$max_ele = round($max_ele * 3.2808399, 0)." ft";
 			$min_ele = round($min_ele * 3.2808399, 0)." ft";
 			$total_ele_up = round($total_ele_up * 3.2808399, 0)." ft";
-			$total_ele_down = round($total_ele_down * 3.2808399, 0)." ft";			
-		} 
+			$total_ele_down = round($total_ele_down * 3.2808399, 0)." ft";
+		}
 		else if ($uom == '2') {
 			// meters / kilometers
 			$tot_len = round($tot_len / 1000, 2)." km";
@@ -525,7 +527,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 			$min_ele = round($min_ele, 0) ." m";
 			$total_ele_up = round($total_ele_up, 0) ." m";
 			$total_ele_down = round($total_ele_down, 0) ." m";
-		} 
+		}
 		else if ($uom == '3') {
 			// meters / kilometers / nautical miles
 			$tot_len = round($tot_len / 1000/1.852, 2)." NM";
@@ -561,7 +563,7 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 
 		$avg_speed = convertSpeed($avg_speed,$uomspeed,true);
 		$waypoints = '[]';
-		
+
 		if ($showW == true) {
 			$wpoints = wpgpxmaps_getWayPoints($gpx);
 			$waypoints = json_encode($wpoints);
@@ -583,39 +585,39 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		$points_graph_atemp = preg_replace($p, "", $points_graph_atemp);
 		$points_graph_cad = preg_replace($p, "", $points_graph_cad);
 		$points_graph_grade = preg_replace($p, "", $points_graph_grade);
-					
+
 		$waypoints = preg_replace($p, "", $waypoints);
-		
-		if (preg_match("/^(0,?)+$/", $points_graph_dist)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_dist))
 			$points_graph_dist = "";
-			
-		if (preg_match("/^(0,?)+$/", $points_graph_ele)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_ele))
 			$points_graph_ele = "";
-			
-		if (preg_match("/^(0,?)+$/", $points_graph_speed)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_speed))
 			$points_graph_speed = "";
-			
-		if (preg_match("/^(0,?)+$/", $points_graph_hr)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_hr))
 			$points_graph_hr = "";
-			
-		if (preg_match("/^(0,?)+$/", $points_graph_hr)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_hr))
 			$points_graph_hr = "";
-			
-		if (preg_match("/^(0,?)+$/", $points_graph_atemp)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_atemp))
 			$points_graph_atemp = "";
-			
-		if (preg_match("/^(0,?)+$/", $points_graph_grade)) 
+
+		if (preg_match("/^(0,?)+$/", $points_graph_grade))
 			$points_graph_grade = "";
-		
+
 	}
-	
+
 	$ngimgs_data = '';
 	if ( $ngGalleries != '' || $ngImages != '' ) {
-	
+
 		$ngimgs = getNGGalleryImages($ngGalleries, $ngImages, $points_x_time, $points_x_lat, $points_x_lon, $dtoffset, $error);
-		$ngimgs_data ='';	
-			
-		foreach ($ngimgs as $img) {		
+		$ngimgs_data ='';
+
+		foreach ($ngimgs as $img) {
 			$data = $img['data'];
 			$data = str_replace("\n","",$data);
 			$ngimgs_data .= '<span lat="'.$img['lat'].'" lon="'.$img['lon'].'">'.$data.'</span>';
@@ -624,25 +626,25 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 // Folgende Zeilen hinzugefügt
 	if ($attachments == true) {
 		$attimgs = wpgpxmaps_getAttachedImages($points_x_time, $points_x_lat, $points_x_lon, $dtoffset, $error);
-		foreach ($attimgs as $img) {		
+		foreach ($attimgs as $img) {
 			$data = $img['data'];
 			$data = str_replace("\n","",$data);
 			$ngimgs_data .= '<span lat="'.$img['lat'].'" lon="'.$img['lon'].'">'.$data.'</span>';
 		}
 	}
-	
+
 	if (!($skipcache == true)) {
-	
-		@file_put_contents($gpxcache, 
-					   serialize(array( "points_maps"         => $points_maps, 
+
+		@file_put_contents($gpxcache,
+					   serialize(array( "points_maps"         => $points_maps,
 										"points_x_time"       => $points_x_time,
 										"points_x_lat"        => $points_x_lat,
 										"points_x_lon"        => $points_x_lon,
-										"points_graph_dist"   => $points_graph_dist, 
-										"points_graph_ele"    => $points_graph_ele, 
-										"points_graph_speed"  => $points_graph_speed, 
-										"points_graph_hr"     => $points_graph_hr, 
-										"points_graph_atemp"  => $points_graph_atemp, 
+										"points_graph_dist"   => $points_graph_dist,
+										"points_graph_ele"    => $points_graph_ele,
+										"points_graph_speed"  => $points_graph_speed,
+										"points_graph_hr"     => $points_graph_hr,
+										"points_graph_atemp"  => $points_graph_atemp,
 										"points_graph_cad"    => $points_graph_cad,
 										"points_graph_grade"  => $points_graph_grade,
 										"waypoints"           => $waypoints,
@@ -658,21 +660,21 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 										"max_time"			  => $max_time,
 										"min_time"			  => $min_time
 										)
-								), 
+								),
 					   LOCK_EX);
-		@chmod($gpxcache,0755);		
+		@chmod($gpxcache,0755);
 	}
-	
+
 	$hideGraph = ($gh == "0" || $gh == "0px");
-	
+
 	global $post;
-	$r = $post->ID."_".rand(1,5000000);	
-	
+	$r = $post->ID."_".rand(1,5000000);
+
 	$output = '
 		<div id="wpgpxmaps_'.$r.'" class="wpgpxmaps">
 			<div id="map_'.$r.'_cont" style="width:'.$w.'; height:'.$mh.';position:relative" >
 				<div id="map_'.$r.'" style="width:'.$w.'; height:'.$mh.'"></div>
-				<div id="wpgpxmaps_'.$r.'_osm_footer" class="wpgpxmaps_osm_footer" style="display:none;"><span> &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</span></div>			
+				<div id="wpgpxmaps_'.$r.'_osm_footer" class="wpgpxmaps_osm_footer" style="display:none;"><span> &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</span></div>
 			</div>
 			<canvas id="myChart_'.$r.'" class="plot" style="width:'.$w.'; height:'.$gh.'"></canvas>
 			<div id="ngimages_'.$r.'" class="ngimages" style="display:none">'.$ngimgs_data.'</div>
@@ -680,10 +682,10 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 		</div>
 		'. $error .'
 		<script type="text/javascript">
-		
+
 			jQuery(document).ready(function() {
-		
-				jQuery("#wpgpxmaps_'.$r.'").wpgpxmaps({ 
+
+				jQuery("#wpgpxmaps_'.$r.'").wpgpxmaps({
 					targetId    : "'.$r.'",
 					mapType     : "'.$mt.'",
 					mapData     : ['.$points_maps.'],
@@ -714,75 +716,75 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 					waypointIcon : "'.$waypointIcon.'",
 					currentpositioncon : "'.$currentpositioncon.'",
 					usegpsposition : "'.$usegpsposition.'",
-					zoomOnScrollWheel : "'.$zoomOnScrollWheel.'", 
+					zoomOnScrollWheel : "'.$zoomOnScrollWheel.'",
 					ngGalleries : ['.$ngGalleries.'],
 					ngImages : ['.$ngImages.'],
 					pluginUrl : "'.plugins_url().'",
 					TFApiKey : "'.get_option('wpgpxmaps_openstreetmap_apikey').'",
-					langs : { altitude              : "'.__("Altitude", "wp-gpx-maps").'",
-							  currentPosition       : "'.__("Current Position", "wp-gpx-maps").'",
-							  speed                 : "'.__("Speed", "wp-gpx-maps").'", 
-							  grade                 : "'.__("Grade", "wp-gpx-maps").'", 
-							  heartRate             : "'.__("Heart rate", "wp-gpx-maps").'", 
-							  atemp             	: "'.__("Temperature", "wp-gpx-maps").'", 
-							  cadence               : "'.__("Cadence", "wp-gpx-maps").'",
-							  goFullScreen          : "'.__("Go Full Screen", "wp-gpx-maps").'",
-							  exitFullFcreen        : "'.__("Exit Full Screen", "wp-gpx-maps").'",
-							  hideImages            : "'.__("Hide Images", "wp-gpx-maps").'",
-							  showImages            : "'.__("Show Images", "wp-gpx-maps").'",
-							  backToCenter		    : "'.__("Back to center", "wp-gpx-maps").'"
+					langs : { altitude              : "'.__( 'Altitude', 'wp-gpx-maps' ).'",
+							  currentPosition       : "'.__( 'Current position', 'wp-gpx-maps' ).'",
+							  speed                 : "'.__( 'Speed', 'wp-gpx-maps' ).'",
+							  grade                 : "'.__( 'Grade', 'wp-gpx-maps' ).'",
+							  heartRate             : "'.__( 'Heart rate', 'wp-gpx-maps' ).'",
+							  atemp             	: "'.__( 'Temperature', 'wp-gpx-maps' ).'",
+							  cadence               : "'.__( 'Cadence', 'wp-gpx-maps' ).'",
+							  goFullScreen          : "'.__( 'Go full screen', 'wp-gpx-maps' ).'",
+							  exitFullFcreen        : "'.__( 'Exit full screen', 'wp-gpx-maps' ).'",
+							  hideImages            : "'.__( 'Hide images', 'wp-gpx-maps' ).'",
+							  showImages            : "'.__( 'Show images', 'wp-gpx-maps' ).'",
+							  backToCenter		    : "'.__( 'Back to center', 'wp-gpx-maps' ).'"
 							}
-				});				
-				
+				});
+
 			});
-	
-		</script>';	
+
+		</script>';
 
 	// print summary
 	if ($summary=='true' && ( $points_graph_speed != '' || $points_graph_ele != '' || $points_graph_dist != '') ) {
-	
+
 		$output .= "<div id='wpgpxmaps_summary_".$r."' class='wpgpxmaps_summary'>";
 		if ($points_graph_dist != '' && $p_tot_len == 'true')
 		{
-			$output .= "<span class='totlen'><span class='summarylabel'>".__("Total distance", "wp-gpx-maps").":</span><span class='summaryvalue'> $tot_len</span></span><br />";
+			$output .= "<span class='totlen'><span class='summarylabel'>".__( 'Total distance', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $tot_len</span></span><br />";
 		}
 		if ($points_graph_ele != '')
 		{
 			if ($p_max_ele == 'true')
-				$output .= "<span class='maxele'><span class='summarylabel'>".__("Max elevation", "wp-gpx-maps").":</span><span class='summaryvalue'> $max_ele</span></span><br />";
+				$output .= "<span class='maxele'><span class='summarylabel'>".__( 'Max elevation', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $max_ele</span></span><br />";
 			if ($p_min_ele == 'true')
-				$output .= "<span class='minele'><span class='summarylabel'>".__("Min elevation", "wp-gpx-maps").":</span><span class='summaryvalue'> $min_ele</span></span><br />";
+				$output .= "<span class='minele'><span class='summarylabel'>".__( 'Min elevation', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $min_ele</span></span><br />";
 			if ($p_total_ele_up == 'true')
-				$output .= "<span class='totaleleup'><span class='summarylabel'>".__("Total climbing", "wp-gpx-maps").":</span><span class='summaryvalue'> $total_ele_up</span></span><br />";
+				$output .= "<span class='totaleleup'><span class='summarylabel'>".__( 'Total climbing', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $total_ele_up</span></span><br />";
 			if ($p_total_ele_down == 'true')
-				$output .= "<span class='totaleledown'><span class='summarylabel'>".__("Total descent", "wp-gpx-maps").":</span><span class='summaryvalue'> $total_ele_down</span></span><br />";
+				$output .= "<span class='totaleledown'><span class='summarylabel'>".__( 'Total descent', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $total_ele_down</span></span><br />";
 		}
 		if ($points_graph_speed != '' && $p_avg_speed == 'true')
 		{
-			$output .= "<span class='avgspeed'><span class='summarylabel'>".__("Average speed", "wp-gpx-maps").":</span><span class='summaryvalue'> $avg_speed</span></span><br />";
+			$output .= "<span class='avgspeed'><span class='summarylabel'>".__( 'Average speed', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $avg_speed</span></span><br />";
 		}
 		if ($points_graph_cad != '' && $p_avg_cad == 'true')
 		{
-			$output .= "<span class='avgcad'><span class='summarylabel'>".__("Average cadence", "wp-gpx-maps").":</span><span class='summaryvalue'> $avg_cad</span></span><br />";
+			$output .= "<span class='avgcad'><span class='summarylabel'>".__( 'Average cadence', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $avg_cad</span></span><br />";
 		}
 		if ($points_graph_hr != '' && $p_avg_hr == 'true')
 		{
-			$output .= "<span class='avghr'><span class='summarylabel'>".__("Average Heartrate", "wp-gpx-maps").":</span><span class='summaryvalue'> $avg_hr</span></span><br />";
+			$output .= "<span class='avghr'><span class='summarylabel'>".__( 'Average heart rate', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $avg_hr</span></span><br />";
 		}
-		
+
 		if ($points_graph_atemp != '' && $p_avg_temp == 'true')
 		{
-			$output .= "<span class='avgtemp'><span class='summarylabel'>".__("Average Temperature", "wp-gpx-maps").":</span><span class='summaryvalue'> $avg_temp</span></span><br />";
+			$output .= "<span class='avgtemp'><span class='summarylabel'>".__( 'Average temperature', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $avg_temp</span></span><br />";
 		}
-		
+
 		if ($p_total_time == 'true' && $max_time > 0)
-		{		
+		{
 			$time_diff = date("H:i:s", ($max_time - $min_time));
-			$output .= "<span class='totaltime'><span class='summarylabel'>".__("Total Time", "wp-gpx-maps").":</span><span class='summaryvalue'> $time_diff</span></span><br />";			
+			$output .= "<span class='totaltime'><span class='summarylabel'>".__( 'Total time', 'wp-gpx-maps' ).":</span><span class='summaryvalue'> $time_diff</span></span><br />";
 		}
 		$output .= "</div>";
 	}
-	
+
 	// print download link
 	if ($download=='true' && $gpxurl != '') {
 		if ($isGpxUrl == true) {
@@ -792,8 +794,8 @@ function handle_WP_GPX_Maps_Shortcodes($attr, $content='')
 			// wpml fix
 			$dummy = ( defined('WP_SITEURL') ) ? WP_SITEURL : get_bloginfo('url');
 			$gpxurl = $dummy.$gpxurl;
-		}		
-		$output.="<a href='$gpxurl' target='_new' download>".__("Download", "wp-gpx-maps")."</a>";
+		}
+		$output.="<a href='$gpxurl' target='_new' download>".__( 'Download', 'wp-gpx-maps' )."</a>";
 	}
 
 	return $output;
@@ -810,32 +812,32 @@ function convertSeconds($s){
 
 function convertSpeed($speed,$uomspeed, $addUom = false){
 	$uom = '';
-	if ($uomspeed == '6') /* min/100 meters */	{		
-		$speed = 1 / $speed * 100 / 60 ;		
-		$uom = " min/100m";	
+	if ($uomspeed == '6') /* min/100 meters */	{
+		$speed = 1 / $speed * 100 / 60 ;
+		$uom = " min/100m";
 	} 	else if ($uomspeed == '5') /* knots */	{
-		$speed *= 1.94384449;		
+		$speed *= 1.94384449;
 		$uom = " knots";
 	} 	else if ($uomspeed == '4') /* min/mi */	{
-		$speed = convertSeconds($speed * 0.037282272);			
+		$speed = convertSeconds($speed * 0.037282272);
 		$uom = " min/mi";
 	} 	else if ($uomspeed == '3') /* min/km */	{
-		$speed = convertSeconds($speed * 0.06);		
+		$speed = convertSeconds($speed * 0.06);
 		$uom = " min/km";
 	} 	else if ($uomspeed == '2') /* miles/h */	{
-		$speed *= 2.2369362920544025;		
+		$speed *= 2.2369362920544025;
 		$uom = " mi/h";
 	} 	else if ($uomspeed == '1') /* km/h */	{
-		$speed *= 3.6;		
+		$speed *= 3.6;
 		$uom = " km/h";
-	}	else	/* dafault m/s */	{				
-		$uom = " m/s";			
-	}	
-	
-	if ($addUom == true)	{		
-		return number_format ( $speed , 2 , '.' , '' ) . $uom;	
-	}	else	{		
-		return number_format ( $speed , 2 , '.' , '' );	
+	}	else	/* dafault m/s */	{
+		$uom = " m/s";
+	}
+
+	if ($addUom == true)	{
+		return number_format ( $speed , 2 , '.' , '' ) . $uom;
+	}	else	{
+		return number_format ( $speed , 2 , '.' , '' );
 	}
 }
 
@@ -843,14 +845,14 @@ function downloadRemoteFile($remoteFile)
 {
 	try
 	{
-		$newfname = tempnam ( '/tmp', 'gpx' );	
-		
+		$newfname = tempnam ( '/tmp', 'gpx' );
+
 		if (function_exists ( "file_put_contents" )) // PHP 5.1.0 +
-		{					
+		{
 			file_put_contents($newfname , fopen($remoteFile, 'r'));
 			return $newfname;
-		} 
-		
+		}
+
 		$file = fopen ($remoteFile, "rb");
 		if ($file) {
 			$newf = fopen ($newfname, "wb");
@@ -868,13 +870,13 @@ function downloadRemoteFile($remoteFile)
 		if ($newf) {
 			fclose($newf);
 		}
-			
-		return $newfname;		
-		
+
+		return $newfname;
+
 	} catch (Exception $e) {
-	
+
 		print_r($e);
-		
+
 		return '';
 	}
 }
@@ -917,7 +919,7 @@ function WP_GPX_Maps_install() {
 	add_option('wpgpxmaps_show_cadence','','','yes');
 	add_option('wpgpxmaps_zoomonscrollwheel','','','yes');
 	add_option('wpgpxmaps_download','','','yes');
-	add_option('wpgpxmaps_summary','','','yes');	
+	add_option('wpgpxmaps_summary','','','yes');
 	add_option('wpgpxmaps_skipcache','','','yes');
 }
 

--- a/wp-gpx-maps_admin.php
+++ b/wp-gpx-maps_admin.php
@@ -16,7 +16,7 @@ function wpgpxmaps_admin_menu() {
 
 		add_options_page('WP GPX Maps', 'WP GPX Maps', 'manage_options', 'WP-GPX-Maps', 'WP_GPX_Maps_html_page');
 
-	} 
+	}
 
 	else if ( current_user_can('publish_posts') ) {
 
@@ -36,14 +36,18 @@ function wpgpxmaps_ilc_admin_tabs( $current  ) {
 
 	{
 
-		$tabs = array( 'tracks' => 'Tracks', 'settings' => 'Settings', 'help' => "help" );	
-
+		$tabs = array(
+				'tracks' => __( 'Tracks', 'wp-gpx-maps' ),
+				'settings' => __( 'Settings', 'wp-gpx-maps' ),
+				'help' => __( 'Help', 'wp-gpx-maps' )
+				);
 	}
-
 	else if ( current_user_can('publish_posts') ) {
 
-		$tabs = array( 'tracks' => 'Tracks', 'help' => "help" );	
-
+		$tabs = array(
+				'tracks' => __( 'Tracks', 'wp-gpx-maps' ),
+				'help' => __( 'Help', 'wp-gpx-maps' )
+				);
 	}
 
 
@@ -74,27 +78,20 @@ function WP_GPX_Maps_html_page() {
 
 	$relativeGpxPath = str_replace("\\","/", $relativeGpxPath);
 
-	
-
 	$tab = $_GET['tab'];
 
-	
 
 	if ($tab == '')
 
 		$tab = 'tracks';
 
-	
-
 ?>
 
 	<div id="icon-themes" class="icon32"><br></div>
 
-		<h2>WP GPX Settings</h2>	
+		<h2><?php _e( 'Settings', 'wp-gpx-maps' ); ?></h2>
 
 <?php
-
-
 
 	if(file_exists($realGpxPath) && is_dir($realGpxPath))
 
@@ -109,20 +106,14 @@ function WP_GPX_Maps_html_page() {
 	{
 
 		if (!@mkdir($realGpxPath,0755,true)) {
-
-			echo '<div class="error" style="padding:10px">
-
-					Can\'t create <b>'.$realGpxPath.'</b> folder. Please create it and make it writable!<br />
-
-					If not, you will must update the file manually!
-
-				  </div>';
-
+			echo '<div class=" notice notice-error"><p>';
+			_e( 'Can\'t create', 'wp-gpx-maps' );
+			echo ''.$realGpxPath.'';
+			_e( 'folder. Please create it and make it writable! If not, you will must update the file manually!', 'wp-gpx-maps' );
+			echo '</p></div>';
 		}
 
 	}
-
-	
 
 	if(file_exists($cacheGpxPath) && is_dir($cacheGpxPath))
 
@@ -137,24 +128,18 @@ function WP_GPX_Maps_html_page() {
 	{
 
 		if (!@mkdir($cacheGpxPath,0755,true)) {
-
-			echo '<div class="error" style="padding:10px">
-
-					Can\'t create <b>'.$cacheGpxPath.'</b> folder. Please create it and make it writable!<br />
-
-					If not, cache will not created and your site could be slower!
-
-				  </div>';
-
+			echo '<div class=" notice notice-error"><p>';
+			_e( 'Can\'t create', 'wp-gpx-maps' );
+			echo ''.cacheGpxPath.'';
+			_e( 'folder. Please create it and make it writable! If not, you will must update the file manually!', 'wp-gpx-maps' );
+			echo '</p></div>';
 		}
 
 	}
 
 
 
-	wpgpxmaps_ilc_admin_tabs($tab);	
-
-	
+	wpgpxmaps_ilc_admin_tabs($tab);
 
 	if ($tab == "tracks")
 
@@ -296,7 +281,7 @@ function WP_GPX_Maps_html_page() {
 
 			</ul>
 
-		
+
 
 			<p>
 
@@ -304,7 +289,7 @@ function WP_GPX_Maps_html_page() {
 
 			</p>
 
-			
+
 
 		</p>
 

--- a/wp-gpx-maps_admin_settings.php
+++ b/wp-gpx-maps_admin_settings.php
@@ -4,7 +4,7 @@
 
 		return;
 	$po = get_option('wpgpxmaps_pointsoffset');
-	$showW = get_option("wpgpxmaps_show_waypoint");	
+	$showW = get_option("wpgpxmaps_show_waypoint");
 	$donotreducegpx = get_option("wpgpxmaps_donotreducegpx");
 	$t = get_option('wpgpxmaps_map_type');
 	$uom = get_option('wpgpxmaps_unit_of_measure');
@@ -15,22 +15,22 @@
 	$showAtemp = get_option('wpgpxmaps_show_atemp');
 	$showCad = get_option('wpgpxmaps_show_cadence');
 	$showGrade = get_option('wpgpxmaps_show_grade');
-	$zoomonscrollwheel = get_option("wpgpxmaps_zoomonscrollwheel");	
+	$zoomonscrollwheel = get_option("wpgpxmaps_zoomonscrollwheel");
 	$download = get_option("wpgpxmaps_download");
 	$skipcache = get_option("wpgpxmaps_skipcache");
-	$summary = get_option("wpgpxmaps_summary");	
+	$summary = get_option("wpgpxmaps_summary");
 	$tot_len = get_option("wpgpxmaps_summary_tot_len");
-	$min_ele = get_option("wpgpxmaps_summary_min_ele");	
-	$max_ele = get_option("wpgpxmaps_summary_max_ele");	
+	$min_ele = get_option("wpgpxmaps_summary_min_ele");
+	$max_ele = get_option("wpgpxmaps_summary_max_ele");
 	$total_ele_up = get_option("wpgpxmaps_summary_total_ele_up");
 	$total_ele_down = get_option("wpgpxmaps_summary_total_ele_down");
 	$avg_speed = get_option("wpgpxmaps_summary_avg_speed");
 	$avg_cad = get_option("wpgpxmaps_summary_avg_cad");
-	$$avg_hr = get_option("wpgpxmaps_summary_avg_hr");
+	$avg_hr = get_option("wpgpxmaps_summary_avg_hr");
 	$avg_temp = get_option("wpgpxmaps_summary_avg_temp");
 	$total_time = get_option("wpgpxmaps_summary_total_time");
-	$usegpsposition = get_option("wpgpxmaps_usegpsposition");	
-	$distanceType = get_option("wpgpxmaps_distance_type");			
+	$usegpsposition = get_option("wpgpxmaps_usegpsposition");
+	$distanceType = get_option("wpgpxmaps_distance_type");
 
 
 	if (empty($showEle))
@@ -48,162 +48,160 @@
 <form method="post" action="options.php">
 	<?php wp_nonce_field('update-options') ?>
 
-	<h3 class="title">General</h3>
+	<h3 class="title"><?php _e( 'General', 'wp-gpx-maps' ); ?></h3>
 
 	<table class="form-table">
 		<tr>
-			<th scope="row">Width:</th>
+			<th scope="row"><?php _e( 'Map width:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_width" type="text" id="wpgpxmaps_width" value="<?php echo get_option('wpgpxmaps_width'); ?>" style="width:50px;" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Map Height:</th>
+			<th scope="row"><?php _e( 'Map height:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_height" type="text" id="wpgpxmaps_height" value="<?php echo get_option('wpgpxmaps_height'); ?>" style="width:50px;" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Graph Height:</th>
+			<th scope="row"><?php _e( 'Graph height:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_graph_height" type="text" id="wpgpxmaps_graph_height" value="<?php echo get_option('wpgpxmaps_graph_height'); ?>" style="width:50px;" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Distance type:</th>
+			<th scope="row"><?php _e( 'Distance type:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<select name='wpgpxmaps_distance_type'>
-					<option value="0" <?php if ($distanceType == '0' || $distanceType == '') echo 'selected'; ?>>Normal (default)</option>
-					<option value="1" <?php if ($distanceType == '1') echo 'selected'; ?>>Flat &#8594; (Only flat distance, don't take care of altitude)</option>
-					<option value="2" <?php if ($distanceType == '2') echo 'selected'; ?>>Climb &#8593; (Only climb distance)</option>
+					<option value="0" <?php if ($distanceType == '0' || $distanceType == '') echo 'selected'; ?>><?php _e( 'Normal (default)', 'wp-gpx-maps' ); ?></option>
+					<option value="1" <?php if ($distanceType == '1') echo 'selected'; ?>><?php _e( 'Flat &#8594; (Only flat distance, don`t take care of altitude)', 'wp-gpx-maps' ); ?></option>
+					<option value="2" <?php if ($distanceType == '2') echo 'selected'; ?>><?php _e( 'Climb &#8593; (Only climb distance)', 'wp-gpx-maps' ); ?></option>
 				</select>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Cache:</th>
+			<th scope="row"><?php _e( 'Cache:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_skipcache" type="checkbox" value="true" <?php if($skipcache == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Do not use cache</i>
+				<input name="wpgpxmaps_skipcache" type="checkbox" value="true" <?php if($skipcache == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Do not use cache', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">GPX Download:</th>
+			<th scope="row"><?php _e( 'GPX Download:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_download" type="checkbox" value="true" <?php if($download == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Allow users to download your GPX file</i>
+				<input name="wpgpxmaps_download" type="checkbox" value="true" <?php if($download == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><?php _e( 'Allow users to download your GPX file', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Use browser GPS position:</th>
+			<th scope="row"><?php _e( 'Use browser GPS position:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_usegpsposition" type="checkbox" value="true" <?php if($usegpsposition == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Allow users to use browser GPS in order to display their current position on map</i>
+				<input name="wpgpxmaps_usegpsposition" type="checkbox" value="true" <?php if($usegpsposition == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Allow users to use browser GPS in order to display their current position on map', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
-		<tr>			
-			<th scope="row">Thunderforest api key (Open Cycle Map):</th>			
-			<td>				
-				<input name="wpgpxmaps_openstreetmap_apikey" type="text" id="wpgpxmaps_openstreetmap_apikey" value="<?php echo get_option('wpgpxmaps_openstreetmap_apikey'); ?>" style="width:400px" /> <em> Go to <a href="http://www.thunderforest.com/docs/apikeys/" target="_blank">Thunderforest API Keys</a> and click &#8216;signing in to your Thunderforest account&#8217; </em>			
-			</td>		
-		</tr>	
+		<tr>
+			<th scope="row"><?php _e( 'Thunderforest API key (Open Cycle Map):', 'wp-gpx-maps' ); ?></th>
+			<td>
+				<input name="wpgpxmaps_openstreetmap_apikey" type="text" id="wpgpxmaps_openstreetmap_apikey" value="<?php echo get_option('wpgpxmaps_openstreetmap_apikey'); ?>" style="width:400px" /> <em> Go to <a href="http://www.thunderforest.com/docs/apikeys/" target="_blank">Thunderforest API Keys</a> and click &#8216;signing in to your Thunderforest account&#8217; </em>
+			</td>
+		</tr>
 
 	</table>
 
 	<p class="submit">
 		<input type="hidden" name="action" value="update" />
     	<input name="page_options" type="hidden" value="wpgpxmaps_height,wpgpxmaps_graph_height,wpgpxmaps_width,wpgpxmaps_download,wpgpxmaps_skipcache,wpgpxmaps_distance_type,wpgpxmaps_usegpsposition,wpgpxmaps_openstreetmap_apikey" />
-		<input type="submit" class="button-primary" value="<?php _e('Save Changes', "wp_gpx_maps") ?>" />
+		<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'wp-gpx-maps' ) ?>" />
 	</p>
 
 </form>
 
 	<hr />
 
-
 <form method="post" action="options.php">
-
 	<?php wp_nonce_field('update-options') ?>
-	<h3 class="title">Summary table</h3>
+
+	<h3 class="title"><?php _e( 'Summary table', 'wp-gpx-maps' ); ?></h3>
+
 	<table class="form-table">
-
 		<tr>
-			<th scope="row">Summary table:</th>
+			<th scope="row"><?php _e( 'Summary table:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary" type="checkbox" value="true" <?php if($summary == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print summary table</i>
+				<input name="wpgpxmaps_summary" type="checkbox" value="true" <?php if($summary == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print summary table', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Total distance:</th>
+			<th scope="row"><?php _e( 'Total distance:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_tot_len" type="checkbox" value="true" <?php if($tot_len == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Total distance</i>
+				<input name="wpgpxmaps_summary_tot_len" type="checkbox" value="true" <?php if($tot_len == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print total distance', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Max Elevation:</th>
+			<th scope="row"><?php _e( 'Max elevation:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_max_ele" type="checkbox" value="true" <?php if($max_ele == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Max Elevation</i>
+				<input name="wpgpxmaps_summary_max_ele" type="checkbox" value="true" <?php if($max_ele == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print max elevation', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Min Elevation:</th>
+			<th scope="row"><?php _e( 'Min elevation:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_min_ele" type="checkbox" value="true" <?php if($min_ele == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Min Elevation</i>
+				<input name="wpgpxmaps_summary_min_ele" type="checkbox" value="true" <?php if($min_ele == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print min elevation', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Total climbing:</th>
+			<th scope="row"><?php _e( 'Total climbing:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_total_ele_up" type="checkbox" value="true" <?php if($total_ele_up == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Total climbing</i>
+				<input name="wpgpxmaps_summary_total_ele_up" type="checkbox" value="true" <?php if($total_ele_up == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print total climbing', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Total Descent:</th>
+			<th scope="row"><?php _e( 'Total descent:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_total_ele_down" type="checkbox" value="true" <?php if($total_ele_down == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Total descent</i>
+				<input name="wpgpxmaps_summary_total_ele_down" type="checkbox" value="true" <?php if($total_ele_down == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print total descent', 'wp-gpx-maps' ); ?></i>
+		</tr>
+
+		<tr>
+			<th scope="row"><?php _e( 'Average speed:', 'wp-gpx-maps' ); ?></th>
+			<td>
+				<input name="wpgpxmaps_summary_avg_speed" type="checkbox" value="true" <?php if($avg_speed == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print average speed', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Average Speed:</th>
+			<th scope="row"><?php _e( 'Average cadence:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_avg_speed" type="checkbox" value="true" <?php if($avg_speed == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Average Speed</i>
+				<input name="wpgpxmaps_summary_avg_cad" type="checkbox" value="true" <?php if($avg_cad == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print average cadence', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Average Cadence:</th>
+			<th scope="row"><?php _e( 'Average heart rate:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_avg_cad" type="checkbox" value="true" <?php if($avg_cad == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Average Cadence</i>
-			</td>
-		</tr>
-		
-		<tr>
-			<th scope="row">Average Heart Rate:</th>
-			<td>
-				<input name="wpgpxmaps_summary_avg_hr" type="checkbox" value="true" <?php if($avg_hr == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Average Heart Rate</i>
-			</td>
-		</tr>
-		
-		<tr>
-			<th scope="row">Average Temperature:</th>
-			<td>
-				<input name="wpgpxmaps_summary_avg_temp" type="checkbox" value="true" <?php if($avg_temp == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Average Temperature</i>
+				<input name="wpgpxmaps_summary_avg_hr" type="checkbox" value="true" <?php if($avg_hr == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print average heart rate', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Total time:</th>
+			<th scope="row"><?php _e( 'Average temperature:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_summary_total_time" type="checkbox" value="true" <?php if($total_time == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Print Total time</i>
+				<input name="wpgpxmaps_summary_avg_temp" type="checkbox" value="true" <?php if($avg_temp == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print average temperature', 'wp-gpx-maps' ); ?></i>
+			</td>
+		</tr>
+
+		<tr>
+			<th scope="row"><?php _e( 'Total time:', 'wp-gpx-maps' ); ?></th>
+			<td>
+				<input name="wpgpxmaps_summary_total_time" type="checkbox" value="true" <?php if($total_time == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Print total time', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
@@ -212,86 +210,88 @@
 	<p class="submit">
 		<input type="hidden" name="action" value="update" />
     	<input name="page_options" type="hidden" value="wpgpxmaps_summary,wpgpxmaps_summary_tot_len,wpgpxmaps_summary_max_ele,wpgpxmaps_summary_min_ele,wpgpxmaps_summary_total_ele_up,wpgpxmaps_summary_total_ele_down,wpgpxmaps_summary_avg_speed,wpgpxmaps_summary_avg_cad,wpgpxmaps_summary_avg_hr,wpgpxmaps_summary_avg_temp,wpgpxmaps_summary_total_time" />
-		<input type="submit" class="button-primary" value="<?php _e('Save Changes', "wp_gpx_maps") ?>" />
+		<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'wp-gpx-maps' ) ?>" />
 	</p>
 
 </form>
+
 	<hr />
 
 <form method="post" action="options.php">
 	<?php wp_nonce_field('update-options') ?>
-	<h3 class="title">Map</h3>
-	
+
+	<h3 class="title"><?php _e( 'Map', 'wp-gpx-maps' ); ?></h3>
+
 	<table class="form-table">
 
 		<tr>
-			<th scope="row">On mouse scroll wheel:</th>
+			<th scope="row"><?php _e( 'On mouse scroll wheel:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_zoomonscrollwheel" type="checkbox" value="true" <?php if($zoomonscrollwheel == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Enable zoom</i>
+				<input name="wpgpxmaps_zoomonscrollwheel" type="checkbox" value="true" <?php if($zoomonscrollwheel == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Enable zoom', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Waypoints Support:</th>
+			<th scope="row"><?php _e( 'Waypoints support:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_show_waypoint" type="checkbox" value="true" <?php if($showW == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Show Waypoints</i>
+				<input name="wpgpxmaps_show_waypoint" type="checkbox" value="true" <?php if($showW == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Show waypoints', 'wp-gpx-maps' ); ?></i>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Map line color:</th>
+			<th scope="row"><?php _e( 'Map line color:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_map_line_color" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_map_line_color'); ?>" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Default Map Type:</th>
+			<th scope="row"><?php _e( 'Default map type:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM1" <?php if ($t == 'OSM1') echo 'checked'; ?>> Open Street Map<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM2" <?php if ($t == 'OSM2') echo 'checked'; ?>> Open Cycle Map<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM4" <?php if ($t == 'OSM4') echo 'checked'; ?>> Open Cycle Map - Transport<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM5" <?php if ($t == 'OSM5') echo 'checked'; ?>> Open Cycle Map - Landscape<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM3" <?php if ($t == 'OSM3') echo 'checked'; ?>> Hike & Bike<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM6" <?php if ($t == 'OSM6') echo 'checked'; ?>> MapToolKit - Terrain<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM7" <?php if ($t == 'OSM7') echo 'checked'; ?>> Open Street Map - Humanitarian map style<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM9" <?php if ($t == 'OSM9') echo 'checked'; ?>> Hike & Bike<br />
-				<input type="radio" name="wpgpxmaps_map_type" value="OSM10" <?php if ($t == 'OSM10') echo 'checked'; ?>> Open Sea Map<br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM1" <?php if ($t == 'OSM1') echo 'checked'; ?>><?php _e( ' Open Street Map', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM2" <?php if ($t == 'OSM2') echo 'checked'; ?>><?php _e( ' Open Cycle Map', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM4" <?php if ($t == 'OSM4') echo 'checked'; ?>><?php _e( ' Open Cycle Map - Transport', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM5" <?php if ($t == 'OSM5') echo 'checked'; ?>><?php _e( ' Open Cycle Map - Landscape', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM3" <?php if ($t == 'OSM3') echo 'checked'; ?>><?php _e( ' Hike & Bike', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM6" <?php if ($t == 'OSM6') echo 'checked'; ?>><?php _e( ' MapToolKit - Terrain', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM7" <?php if ($t == 'OSM7') echo 'checked'; ?>><?php _e( ' Open Street Map - Humanitarian map style', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM9" <?php if ($t == 'OSM9') echo 'checked'; ?>><?php _e( ' Hike & Bike', 'wp-gpx-maps' ); ?><br />
+				<input type="radio" name="wpgpxmaps_map_type" value="OSM10" <?php if ($t == 'OSM10') echo 'checked'; ?>><?php _e( ' Open Sea Map', 'wp-gpx-maps' ); ?><br />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Start Icon:</th>
+			<th scope="row"><?php _e( 'Start track icon:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_map_start_icon" value="<?php echo get_option('wpgpxmaps_map_start_icon'); ?>" style="width:400px" /> <em>(Url to image) Leave empty to hide</em>
+				<input name="wpgpxmaps_map_start_icon" value="<?php echo get_option('wpgpxmaps_map_start_icon'); ?>" style="width:400px" /><em><?php _e( ' (URL to image) Leave empty to hide.', 'wp-gpx-maps' ); ?></em>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">End Icon:</th>
+			<th scope="row"><?php _e( 'End track icon:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_map_end_icon" value="<?php echo get_option('wpgpxmaps_map_end_icon'); ?>" style="width:400px" /> <em>(Url to image) Leave empty to hide</em>
+				<input name="wpgpxmaps_map_end_icon" value="<?php echo get_option('wpgpxmaps_map_end_icon'); ?>" style="width:400px" /><em><?php _e( ' (URL to image) Leave empty to hide.', 'wp-gpx-maps' ); ?></em>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Current Position Icon:</th>
+			<th scope="row"><?php _e( 'Current position icon:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_map_current_icon" value="<?php echo get_option('wpgpxmaps_map_current_icon'); ?>" style="width:400px" /> <em>(Url to image) Leave empty for default</em>
+				<input name="wpgpxmaps_map_current_icon" value="<?php echo get_option('wpgpxmaps_map_current_icon'); ?>" style="width:400px" /><em><?php _e( ' (URL to image) Leave empty to hide.', 'wp-gpx-maps' ); ?></em>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Current GPS Position Icon:</th>
+			<th scope="row"><?php _e( 'Current GPS position icon:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_currentpositioncon" value="<?php echo get_option('wpgpxmaps_currentpositioncon'); ?>" style="width:400px" /> <em>(Url to image) Leave empty for default</em>
+				<input name="wpgpxmaps_currentpositioncon" value="<?php echo get_option('wpgpxmaps_currentpositioncon'); ?>" style="width:400px" /><em><?php _e( ' (URL to image) Leave empty to hide.', 'wp-gpx-maps' ); ?></em>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Custom Waypoint Icon:</th>
+			<th scope="row"><?php _e( 'Custom waypoint icon:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_map_waypoint_icon" value="<?php echo get_option('wpgpxmaps_map_waypoint_icon'); ?>" style="width:400px" /> <em>(Url to image) Leave empty for default</em>
+				<input name="wpgpxmaps_map_waypoint_icon" value="<?php echo get_option('wpgpxmaps_map_waypoint_icon'); ?>" style="width:400px" /><em><?php _e( ' (URL to image) Leave empty to hide.', 'wp-gpx-maps' ); ?></em>
 			</td>
 		</tr>
 
@@ -300,7 +300,7 @@
 	<p class="submit">
 		<input type="hidden" name="action" value="update" />
     	<input name="page_options" type="hidden" value="wpgpxmaps_show_waypoint,wpgpxmaps_map_line_color,wpgpxmaps_map_type,wpgpxmaps_map_start_icon,wpgpxmaps_map_end_icon,wpgpxmaps_map_current_icon,wpgpxmaps_zoomonscrollwheel,wpgpxmaps_map_waypoint_icon,wpgpxmaps_currentpositioncon" />
-		<input type="submit" class="button-primary" value="<?php _e('Save Changes', "wp_gpx_maps") ?>" />
+		<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'wp-gpx-maps' ) ?>" />
 	</p>
 
 </form>
@@ -308,145 +308,144 @@
 
 <form method="post" action="options.php">
 	<?php wp_nonce_field('update-options') ?>
-	<h3 class="title">Chart</h3>
+
+	<h3 class="title"><?php _e( 'Chart', 'wp-gpx-maps' ); ?></h3>
 
 	<table class="form-table">
 
 		<tr>
-			<th scope="row">Show altitude:</th>
+			<th scope="row"><?php _e( 'Altitude', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input type="checkbox" <?php if($showEle == "true"){echo('checked');} ?> onchange="wpgpxmaps_show_elevation.value = this.checked" onload="wpgpxmaps_show_elevation.value = this.checked" /> <i>Show Altitude</i>
+				<input type="checkbox" <?php if($showEle == "true"){echo('checked');} ?> onchange="wpgpxmaps_show_elevation.value = this.checked" onload="wpgpxmaps_show_elevation.value = this.checked" /><i><?php _e( 'Show altitude', 'wp-gpx-maps' ); ?></i>
 				<input name="wpgpxmaps_show_elevation" type="hidden" value="<?php echo $showEle; ?>">
 			</td>
 		</tr>
 
 		<tr>
-			<tr>
-				<th scope="row">Altitude line color:</th>
-				<td>
-					<input name="wpgpxmaps_graph_line_color" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color'); ?>" />
-				</td>
-			</tr>		
+			<th scope="row"><?php _e( 'Altitude line color:', 'wp-gpx-maps' ); ?></th>
+			<td>
+				<input name="wpgpxmaps_graph_line_color" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color'); ?>" />
+			</td>
+		</tr>
 
-			<th scope="row">Unit of measure:</th>
-
+		<tr>
+			<th scope="row"><?php _e( 'Unit of measure:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<select name='wpgpxmaps_unit_of_measure'>
-					<option value="0" <?php if ($uom == '0') echo 'selected'; ?>>meters/meters</option>
-					<option value="1" <?php if ($uom == '1') echo 'selected'; ?>>feet/miles</option>
-					<option value="2" <?php if ($uom == '2') echo 'selected'; ?>>meters/kilometers</option>
-					<option value="3" <?php if ($uom == '3') echo 'selected'; ?>>meters/nautical miles</option>
-					<option value="4" <?php if ($uom == '4') echo 'selected'; ?>>meters/miles</option>
-					<option value="5" <?php if ($uom == '5') echo 'selected'; ?>>feet/nautical miles</option>
+					<option value="0" <?php if ($uom == '0') echo 'selected'; ?>><?php _e( 'meters / meters', 'wp-gpx-maps' ); ?></option>
+					<option value="1" <?php if ($uom == '1') echo 'selected'; ?>><?php _e( 'feet / miles', 'wp-gpx-maps' ); ?></option>
+					<option value="2" <?php if ($uom == '2') echo 'selected'; ?>><?php _e( 'meters / kilometers', 'wp-gpx-maps' ); ?></option>
+					<option value="3" <?php if ($uom == '3') echo 'selected'; ?>><?php _e( 'meters / nautical Miles', 'wp-gpx-maps' ); ?></option>
+					<option value="4" <?php if ($uom == '4') echo 'selected'; ?>><?php _e( 'meters / miles', 'wp-gpx-maps' ); ?></option>
+					<option value="5" <?php if ($uom == '5') echo 'selected'; ?>><?php _e( 'feet / nautical miles', 'wp-gpx-maps' ); ?></option>
 				</select>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Altitude display offset:</th>
+			<th scope="row"><?php _e( 'Altitude display offset:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				From
+				<?php _e( 'From', 'wp-gpx-maps' ); ?>
 				<input name="wpgpxmaps_graph_offset_from1" value="<?php echo get_option('wpgpxmaps_graph_offset_from1'); ?>" style="width:50px;" />
-				To
+				<?php _e( 'to', 'wp-gpx-maps' ); ?>
 				<input name="wpgpxmaps_graph_offset_to1" value="<?php echo get_option('wpgpxmaps_graph_offset_to1'); ?>" style="width:50px;" />
-				<em>(leave empty for auto scale)</em>
+				<em><?php _e( '(leave empty for auto scale)', 'wp-gpx-maps' ); ?></em>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Show speed:</th>
+			<th scope="row"><?php _e( 'Speed:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_show_speed" type="checkbox" value="true" <?php if($showSpeed == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Show Speed</i>
+				<input name="wpgpxmaps_show_speed" type="checkbox" value="true" <?php if($showSpeed == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Show speed', 'wp-gpx-maps' ); ?></i>
 			</td>
-		</tr>		
+		</tr>
 
 		<tr>
-			<th scope="row">Speed line color:</th>
+			<th scope="row"><?php _e( 'Speed line color:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_graph_line_color_speed" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color_speed'); ?>" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Speed unit of measure:</th>
+			<th scope="row"><?php _e( 'Speed unit of measure:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<select name='wpgpxmaps_unit_of_measure_speed'>
-					<option value="0" <?php if ($uomSpeed == '0') echo 'selected'; ?>>m/s</option>
-					<option value="1" <?php if ($uomSpeed == '1') echo 'selected'; ?>>km/h</option>
-					<option value="2" <?php if ($uomSpeed == '2') echo 'selected'; ?>>miles/h</option>
-					<option value="3" <?php if ($uomSpeed == '3') echo 'selected'; ?>>min/km</option>
-					<option value="4" <?php if ($uomSpeed == '4') echo 'selected'; ?>>min/miles</option>
-					<option value="5" <?php if ($uomSpeed == '5') echo 'selected'; ?>>Nautical Miles/Hour (Knots)</option>										<option value="6" <?php if ($uomSpeed == '6') echo 'selected'; ?>>min/100 meters</option>
+					<option value="0" <?php if ($uomSpeed == '0') echo 'selected'; ?>><?php _e( 'm/s', 'wp-gpx-maps' ); ?></option>
+					<option value="1" <?php if ($uomSpeed == '1') echo 'selected'; ?>><?php _e( 'km/h', 'wp-gpx-maps' ); ?></option>
+					<option value="2" <?php if ($uomSpeed == '2') echo 'selected'; ?>><?php _e( 'miles/h', 'wp-gpx-maps' ); ?></option>
+					<option value="3" <?php if ($uomSpeed == '3') echo 'selected'; ?>><?php _e( 'min/km', 'wp-gpx-maps' ); ?></option>
+					<option value="4" <?php if ($uomSpeed == '4') echo 'selected'; ?>><?php _e( 'min/miles', 'wp-gpx-maps' ); ?></option>
+					<option value="5" <?php if ($uomSpeed == '5') echo 'selected'; ?>><?php _e( 'Knots (nautical miles / hour)', 'wp-gpx-maps' ); ?></option>
+					<option value="6" <?php if ($uomSpeed == '6') echo 'selected'; ?>><?php _e( 'min/100 meters', 'wp-gpx-maps' ); ?></option>
 				</select>
-			</td>
-		</tr>	
-
-		<tr>
-			<th scope="row">Speed display offset:</th>
-			<td>
-				From
-				<input name="wpgpxmaps_graph_offset_from2" value="<?php echo get_option('wpgpxmaps_graph_offset_from2'); ?>" style="width:50px;" />
-				To
-				<input name="wpgpxmaps_graph_offset_to2" value="<?php echo get_option('wpgpxmaps_graph_offset_to2'); ?>" style="width:50px;" />
-				<em>(leave empty for auto scale)</em>
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Show Heart Rate (where aviable):</th>
+			<th scope="row"><?php _e( 'Speed display offset:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_show_hr" type="checkbox" value="true" <?php if($showHr == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Show heart rate</i>
+				<?php _e( 'From', 'wp-gpx-maps' ); ?>
+				<input name="wpgpxmaps_graph_offset_from2" value="<?php echo get_option('wpgpxmaps_graph_offset_from2'); ?>" style="width:50px;" />
+				<?php _e( 'to', 'wp-gpx-maps' ); ?>
+				<input name="wpgpxmaps_graph_offset_to2" value="<?php echo get_option('wpgpxmaps_graph_offset_to2'); ?>" style="width:50px;" />
+				<em><?php _e( '(leave empty for auto scale)', 'wp-gpx-maps' ); ?></em>
 			</td>
-		</tr>		
+		</tr>
 
 		<tr>
-			<th scope="row">Heart rate line color:</th>
+			<th scope="row"><?php _e( 'Heart rate (where aviable):', 'wp-gpx-maps' ); ?></th>
+			<td>
+				<input name="wpgpxmaps_show_hr" type="checkbox" value="true" <?php if($showHr == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Show heart rate', 'wp-gpx-maps' ); ?></i>
+			</td>
+		</tr>
+
+		<tr>
+			<th scope="row"><?php _e( 'Heart rate line color:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_graph_line_color_hr" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color_hr'); ?>" />
 			</td>
 		</tr>
 
-		
+		<tr>
+			<th scope="row"><?php _e( 'Temperature (where aviable):', 'wp-gpx-maps' ); ?></th>
+			<td>
+				<input name="wpgpxmaps_show_atemp" type="checkbox" value="true" <?php if($showAtemp == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Show temperature', 'wp-gpx-maps' ); ?></i>
+			</td>
+		</tr>
 
 		<tr>
-			<th scope="row">Show Temperature (where aviable):</th>
-			<td>
-				<input name="wpgpxmaps_show_atemp" type="checkbox" value="true" <?php if($showAtemp == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Show Temperature</i>
-			</td>
-		</tr>	
-		
-		<tr>
-			<th scope="row">Temperature line color:</th>
+			<th scope="row"><?php _e( 'Temperature line color:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_graph_line_color_atemp" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color_atemp'); ?>" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Show Cadence (where aviable):</th>
+			<th scope="row"><?php _e( 'Cadence (where aviable):', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_show_cadence" type="checkbox" value="true" <?php if($showCad == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Show Cadence</i>
+				<input name="wpgpxmaps_show_cadence" type="checkbox" value="true" <?php if($showCad == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Show cadence', 'wp-gpx-maps' ); ?></i>
 			</td>
-		</tr>		
+		</tr>
 
 		<tr>
-			<th scope="row">Cadence line color:</th>
+			<th scope="row"><?php _e( 'Cadence line color:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_graph_line_color_cad" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color_cad'); ?>" />
 			</td>
 		</tr>
 
 		<tr>
-			<th scope="row">Show Grade:</th>
+			<th scope="row"><?php _e( 'Grade:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_show_grade" type="checkbox" value="true" <?php if($showGrade == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Show Grade - BETA</i>
+				<input name="wpgpxmaps_show_grade" type="checkbox" value="true" <?php if($showGrade == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Show grade - BETA', 'wp-gpx-maps' ); ?></i>
 				<br />
-				<i>(Grade values depends on your gps accuracy. If you have a poor gps accuracy they might be totally wrong!)</i>
+				<i><?php _e( '(Grade values depends on your GPS accuracy. If you have a poor GPS accuracy they might be totally wrong!)', 'wp-gpx-maps' ); ?></i>
 			</td>
-		</tr>		
+		</tr>
 
 		<tr>
-			<th scope="row">Grade line color:</th>
+			<th scope="row"><?php _e( 'Grade line color:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_graph_line_color_grade" type="color" data-hex="true" value="<?php echo get_option('wpgpxmaps_graph_line_color_grade'); ?>" />
 			</td>
@@ -455,10 +454,9 @@
 	</table>
 
 	<p class="submit">
-
 		<input type="hidden" name="action" value="update" />
     	<input name="page_options" type="hidden" value="wpgpxmaps_unit_of_measure,wpgpxmaps_graph_line_color,wpgpxmaps_show_elevation,wpgpxmaps_show_speed,wpgpxmaps_graph_line_color_speed,wpgpxmaps_show_hr,wpgpxmaps_graph_line_color_hr,wpgpxmaps_unit_of_measure_speed,wpgpxmaps_graph_offset_from1,wpgpxmaps_graph_offset_to1,wpgpxmaps_graph_offset_from2,wpgpxmaps_graph_offset_to2,wpgpxmaps_graph_line_color_cad,wpgpxmaps_show_cadence,wpgpxmaps_show_grade,wpgpxmaps_graph_line_color_grade,wpgpxmaps_show_atemp,wpgpxmaps_graph_line_color_atemp" />
-		<input type="submit" class="button-primary" value="<?php _e('Save Changes', "wp_gpx_maps") ?>" />
+		<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'wp-gpx-maps' ) ?>" />
 	</p>
 
 </form>
@@ -466,23 +464,24 @@
 
 <form method="post" action="options.php">
 	<?php wp_nonce_field('update-options') ?>
-	<h3 class="title">Advanced options	<small>(Do not edit if you don't know what you are doing!)</small></h3>
+
+	<h3 class="title"><?php _e( 'Advanced Options <small>(Do not edit if you don\'t know what you are doing!)</small>', 'wp-gpx-maps' ); ?></h3>
 
 	<table class="form-table">
 
 		<tr>
-			<th scope="row"></th>
+			<th scope="row"><?php _e( 'Skip GPX points closer than:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<i>Skip points closer than </i> <input name="wpgpxmaps_pointsoffset" type="text" id="wpgpxmaps_pointsoffset" value="<?php echo $po ?>" style="width:50px;" /> <i>meters</i>.
+			<input name="wpgpxmaps_pointsoffset" type="text" id="wpgpxmaps_pointsoffset" value="<?php echo $po ?>" style="width:50px;" /><i><?php _e( ' meters', 'wp-gpx-maps' ); ?></i>
 			</td>
-		</tr>		
+		</tr>
 
 		<tr>
-			<th scope="row"></th>
+			<th scope="row"><?php _e( 'Reduce GPX:', 'wp-gpx-maps' ); ?></th>
 			<td>
-				<input name="wpgpxmaps_donotreducegpx" type="checkbox" value="true" <?php if($donotreducegpx == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /> <i>Do not reduce gpx</i>.
+				<input name="wpgpxmaps_donotreducegpx" type="checkbox" value="true" <?php if($donotreducegpx == true){echo('checked');} ?> onchange="this.value = (this.checked)"  /><i><?php _e( 'Do not reduce GPX', 'wp-gpx-maps' ); ?></i>
 			</td>
-		</tr>	
+		</tr>
 
 	</table>
 
@@ -490,7 +489,7 @@
 	<input name="page_options" type="hidden" value="wpgpxmaps_pointsoffset,wpgpxmaps_donotreducegpx" />
 
 	<p class="submit">
-		<input type="submit" class="button-primary" value="<?php _e('Save Changes', "wp_gpx_maps") ?>" />
+		<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'wp-gpx-maps' ) ?>" />
 	</p>
 
 </form>

--- a/wp-gpx-maps_admin_tracks.php
+++ b/wp-gpx-maps_admin_tracks.php
@@ -2,73 +2,84 @@
 
 	if ( !(is_admin()) )
 		return;
-	
+
 	$is_admin = current_user_can( 'publish_posts' );
-	
+
 	if ( $is_admin != 1 )
 		return;
-	
+
 	$gpxRegEx = '/.gpx$/i';
-        if ( current_user_can('manage_options') ){
-            $menu_root = "options-general.php";
-        } else if ( current_user_can('publish_posts') ){
-            $menu_root = "admin.php";
-        }
+	if ( current_user_can('manage_options') ){
+		$menu_root = "options-general.php";
+	} else if ( current_user_can('publish_posts') ){
+		$menu_root = "admin.php";
+	}
 
 	if ( isset($_POST['clearcache']) )
 	{
-		
-		if ( isset($_GET['_wpnonce']) 
-			&& 
-			wp_verify_nonce( $_GET['_wpnonce'], 'wpgpx_clearcache_nonce' . $entry ) 
-			) 
-		{				
-			echo "Cache is now empty!";
-			wpgpxmaps_recursive_remove_directory($cacheGpxPath, true);			
+
+		if ( isset($_GET['_wpnonce'])
+			&&
+			wp_verify_nonce( $_GET['_wpnonce'], 'wpgpx_clearcache_nonce' . $entry )
+			)
+		{
+			echo '<div class="notice notice-success"><p>';
+	    	_e( 'Cache is now empty!', 'wp-gpx-maps' );
+			echo '</p></div>';
+
+			wpgpxmaps_recursive_remove_directory($cacheGpxPath, true);
 		}
-		
+
 	}
 
 	if ( is_writable ( $realGpxPath ) ){
-	
+
 	?>
 
 		<div class="tablenav top">
-<?php
+		<?php
             echo '<form enctype="multipart/form-data" method="POST" style="float:left; margin:5px 20px 0 0" action="' . get_bloginfo('wpurl') . '/wp-admin/' . $menu_root . '?page=WP-GPX-Maps">'; ?>
-				Choose a file to upload: <input name="uploadedfile[]" type="file" onchange="submitgpx(this);" multiple />
+				<?php _e( 'Choose a file to upload:', 'wp-gpx-maps' )?> <input name="uploadedfile[]" type="file" onchange="submitgpx(this);" multiple />
 				<?php
-					if ( isset($_FILES['uploadedfile']) )									
-					{					
+					if ( isset($_FILES['uploadedfile']) )
+					{
 						$total = count($_FILES['uploadedfile']['name']);
 						for($i=0; $i<$total; $i++) {
-							$uploadingFileName = basename( $_FILES['uploadedfile']['name'][$i]); 								
-							$target_path = $realGpxPath ."/". $uploadingFileName; 						
+							$uploadingFileName = basename( $_FILES['uploadedfile']['name'][$i]);
+							$target_path = $realGpxPath ."/". $uploadingFileName;
 							if (preg_match($gpxRegEx, $target_path))
-							{				
+							{
 								if(move_uploaded_file($_FILES['uploadedfile']['tmp_name'][$i], $target_path)) {
-									echo "<br />File <b>".  $uploadingFileName . "</b> has been uploaded";
+									echo '<div class="notice notice-success"><p>';
+									_e( 'The file', 'wp-gpx-maps' );
+									echo ''.$uploadingFileName.'';
+									_e( 'has been successfully uploaded.', 'wp-gpx-maps' );
+									echo '</p></div>';
 								} else{
-									echo "<br />There was an error uploading the file, please try again!";
-								}		
+									echo '<div class=" notice notice-error"><p>';
+									_e( 'There was an error uploading the file, please try again!', 'wp-gpx-maps' );
+									echo '</p></div>';
+								}
 							}
 							else
 							{
-								echo "file not supported!";
-							}														
+								echo '<div class="notice notice-warning"><p>';
+								_e( 'The file type not supported!', 'wp-gpx-maps' );
+								echo '</p></div>';
+							}
 						}
 					}
 				?>
 			</form>
-			
+
 			<form method="POST" style="float:left; margin:5px 20px 0 0" action="/wp-admin/options-general.php?page=WP-GPX-Maps&_wpnonce=<?php echo wp_create_nonce( 'wpgpx_clearcache_nonce' ) ?>" >
-				<input type="submit" name="clearcache" value="Clear Cache" />				
-			</form>		
-			
-		</div>	
-	
+				<input type="submit" name="clearcache" value="<?php _e( 'Clear Cache', 'wp-gpx-maps' ); ?>" />
+			</form>
+
+		</div>
+
 	<?php
-	
+
 	}
 	else
 	{
@@ -78,20 +89,20 @@
 			<p style='font-size:2em;'>please make <b><?php echo $realGpxPath ?></b> folder writable. </p>
 			<br />
 			<br />
-			
-		<?php		
+
+		<?php
 	}
-	
+
 	$myGpxFileNames = array();
-	if ( is_readable ( $realGpxPath ) && $handle = opendir($realGpxPath)) {		
+	if ( is_readable ( $realGpxPath ) && $handle = opendir($realGpxPath)) {
 		while (false !== ($entry = readdir($handle))) {
 			if (preg_match($gpxRegEx, $entry ))
 			{
 
-				if ( isset($_GET['_wpnonce']) 
-					&& 
-					wp_verify_nonce( $_GET['_wpnonce'], 'wpgpx_deletefile_nonce_' . $entry ) 
-					) { 
+				if ( isset($_GET['_wpnonce'])
+					&&
+					wp_verify_nonce( $_GET['_wpnonce'], 'wpgpx_deletefile_nonce_' . $entry )
+					) {
 
 					if ( file_exists($realGpxPath ."/". $entry) )
 					{
@@ -100,27 +111,27 @@
 					}
 					else {
 						echo "<br/><b>Can't delete $entry.</b>";
-						
+
 					}
 				}
 				else
 				{
-					$myFile = $realGpxPath . "/" . $entry;	
+					$myFile = $realGpxPath . "/" . $entry;
 					$myGpxFileNames[] = array(
-											'name' => $entry, 
+											'name' => $entry,
 											'size' => filesize( $myFile ),
 											'lastedit' => filemtime( $myFile ),
 											'nonce' => wp_create_nonce( 'wpgpx_deletefile_nonce_' . $entry ),
-											);					
+											);
 
 				}
 
 			}
 		}
 		closedir($handle);
-	} 
-	
-	if ( is_readable ( $realGpxPath ) && $handle = opendir($realGpxPath)) {		
+	}
+
+	if ( is_readable ( $realGpxPath ) && $handle = opendir($realGpxPath)) {
 			while (false !== ($entry = readdir($handle))) {
 				if (preg_match($gpxRegEx,$entry ))
 				{
@@ -128,30 +139,30 @@
 				}
 			}
 		closedir($handle);
-	} 
-	
+	}
+
 	$wpgpxmaps_gpxRelativePath = get_site_url(null, '/wp-content/uploads/gpx/');
-	
+
 ?>
-	
+
 	<table id="table" class="wp-list-table widefat plugins"></table>
-	
+
 <script type="text/javascript">
 
 	function submitgpx(el)
 	{
-		 var newEl = document.createElement('span'); 
+		 var newEl = document.createElement('span');
 		 newEl.innerHTML = 'Uploading file...';
-		 el.parentNode.insertBefore(newEl,el.nextSibling);  
+		 el.parentNode.insertBefore(newEl,el.nextSibling);
 		 el.parentNode.submit()
 	}
-	
+
 	jQuery('#table').bootstrapTable({
 		columns: [{
 			field: 'name',
 			title: 'File',
 			sortable: true,
-			formatter: function(value, row, index) { 
+			formatter: function(value, row, index) {
 
 				return [
 					'<b>' + row.name + '</b><br />',
@@ -161,13 +172,13 @@
 					' | ',
 					'Shortcode: [sgpx gpx="<?php echo $relativeGpxPath ?>' + row.name + '"]',
 				].join('')
-			
+
 			}
 		}, {
 			field: 'lastedit',
 			title: 'Last modified',
 			sortable: true,
-			formatter: function(value, row, index) { 
+			formatter: function(value, row, index) {
 					var d = new Date(value*1000);
 					return d.toLocaleDateString() + " " + d.toLocaleTimeString();
 				}
@@ -178,14 +189,14 @@
 			formatter: function(value, row, index) { return humanFileSize(value); }
 		}],
 		sortName : 'lastedit',
-		sortOrder : 'desc', 
+		sortOrder : 'desc',
 		data: <?php echo json_encode( $myGpxFileNames ) ?>
-	});	
-	
+	});
+
 	jQuery('.delete_gpx_row').click(function(){
 		return confirm("Are you sure you want to delete?");
 	})
-	
+
 	function humanFileSize(bytes, si) {
 		var thresh = si ? 1000 : 1024;
 		if(Math.abs(bytes) < thresh) {

--- a/wp-gpx-maps_utils.php
+++ b/wp-gpx-maps_utils.php
@@ -7,7 +7,7 @@
 	function wpgpxmaps_getAttachedImages($dt, $lat, $lon, $dtoffset, &$error)
 	{
 		$result = array();
-			
+
 		try {
 			$attachments = get_children( array(
 				 'post_parent'    => get_the_ID(),
@@ -29,12 +29,12 @@
 				$item["data"] = wp_get_attachment_link( $attachment_id, array(105,105) );
 
 				if (is_callable('exif_read_data')) {
-					$exif = @exif_read_data($img_src[0]);	
+					$exif = @exif_read_data($img_src[0]);
 					if ($exif !== false)
 					{
 						$item["lon"] = getExifGps($exif["GPSLongitude"], $exif['GPSLongitudeRef']);
 						$item["lat"] = getExifGps($exif["GPSLatitude"], $exif['GPSLatitudeRef']);
-						if (($item["lat"] != 0) || ($item["lon"] != 0)) 
+						if (($item["lat"] != 0) || ($item["lon"] != 0))
 						{
 							$result[] = $item;
 						}
@@ -56,7 +56,7 @@
 					$error .= "Sorry, <a href='http://php.net/manual/en/function.exif-read-data.php' target='_blank' >exif_read_data</a> function not found! check your hosting..<br />";
 				}
 			}
-			
+
 		} catch (Exception $e) {
 			$error .= 'Error When Retrieving attached images: $e <br />';
 		}
@@ -73,29 +73,29 @@
 	function gpxFolderPath()
 	{
 		$upload_dir = wp_upload_dir();
-		$uploadsPath = $upload_dir['basedir'];	
-		
-		
+		$uploadsPath = $upload_dir['basedir'];
+
+
 		if ( current_user_can('manage_options') ){
 			$ret = $uploadsPath.DIRECTORY_SEPARATOR."gpx";
-		} 
-		else if ( current_user_can('publish_posts') ) {	
+		}
+		else if ( current_user_can('publish_posts') ) {
 			global $current_user;
 			get_currentuserinfo();
 			$ret = $uploadsPath.DIRECTORY_SEPARATOR."gpx".DIRECTORY_SEPARATOR.$current_user->user_login;
-		}		
-		
+		}
+
 		return str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $ret);
 	}
-	
+
 	function gpxCacheFolderPath()
 	{
 		$upload_dir = wp_upload_dir();
-		$uploadsPath = $upload_dir['basedir'];	
+		$uploadsPath = $upload_dir['basedir'];
 		$ret = $uploadsPath.DIRECTORY_SEPARATOR."gpx".DIRECTORY_SEPARATOR."~cache";
 		return str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $ret);
 	}
-	
+
 	function relativeGpxFolderPath()
 	{
 		$sitePath = wp_gpx_maps_sitePath();
@@ -121,7 +121,7 @@
 				if($item != '.' && $item != '..')
 				{
 					$path = $directory.'/'.$item;
-					if(is_dir($path)) 
+					if(is_dir($path))
 					{
 						wpgpxmaps_recursive_remove_directory($path);
 					}else{
@@ -146,21 +146,21 @@
 
 		$points = array();
 		$dist=0;
-		
+
 		$lastLat=0;
 		$lastLon=0;
 		$lastEle=0;
 		$lastOffset=0;
-				
+
 		if (file_exists($gpxPath))
 		{
-			$points = @wpgpxmaps_parseXml($gpxPath, $gpxOffset, $distancetype);			
+			$points = @wpgpxmaps_parseXml($gpxPath, $gpxOffset, $distancetype);
 		}
 		else
 		{
 			echo "WP GPX Maps Error: File $gpxPath not found!";
 		}
-		
+
 		// reduce the points to around 200 to speedup
 		if ( $donotreducegpx != true)
 		{
@@ -173,17 +173,17 @@
 						if ($i % $f != 0 && $points->lat[$i] != null)
 						{
 							unset($points->dt[$i]);
-							unset($points->lat[$i]);						
-							unset($points->lon[$i]);						
-							unset($points->ele[$i]);						
-							unset($points->dist[$i]);						
-							unset($points->speed[$i]);						
+							unset($points->lat[$i]);
+							unset($points->lon[$i]);
+							unset($points->ele[$i]);
+							unset($points->dist[$i]);
+							unset($points->speed[$i]);
 							unset($points->hr[$i]);
 							unset($points->atemp[$i]);
 							unset($points->cad[$i]);
 							unset($points->grade[$i]);
 						}
-			}		
+			}
 		}
 		return $points;
 	}
@@ -192,7 +192,7 @@
 	{
 
 		$points = null;
-		
+
 		$points->dt = array();
 		$points->lat = array();
 		$points->lon = array();
@@ -200,10 +200,10 @@
 		$points->dist = array();
 		$points->speed = array();
 		$points->hr = array();
-		$points->atemp = array();	
+		$points->atemp = array();
 		$points->cad = array();
 		$points->grade = array();
-		
+
 		$points->maxTime = 0;
 		$points->minTime = 0;
 		$points->maxEle = 0;
@@ -215,33 +215,33 @@
 		$points->avgHr = 0;
 		$points->avgTemp = 0;
 		$points->totalLength = 0;
-		
-		$gpx = simplexml_load_file($filePath);	
-		
-		if($gpx === FALSE) 
+
+		$gpx = simplexml_load_file($filePath);
+
+		if($gpx === FALSE)
 			return;
-		
+
 		$gpx->registerXPathNamespace('a', 'http://www.topografix.com/GPX/1/0');
 		$gpx->registerXPathNamespace('b', 'http://www.topografix.com/GPX/1/1');
 		$gpx->registerXPathNamespace('ns3', 'http://www.garmin.com/xmlschemas/TrackPointExtension/v1');
-		
+
 		$nodes = $gpx->xpath('//trk | //a:trk | //b:trk');
 		//normal gpx
-		
-		if ( count($nodes) > 0 )	
+
+		if ( count($nodes) > 0 )
 		{
-		
+
 			foreach($nodes as $_trk)
 			{
-			
-				$trk = simplexml_load_string($_trk->asXML()); 
-				
+
+				$trk = simplexml_load_string($_trk->asXML());
+
 				$trk->registerXPathNamespace('a', 'http://www.topografix.com/GPX/1/0');
 				$trk->registerXPathNamespace('b', 'http://www.topografix.com/GPX/1/1');
 				$trk->registerXPathNamespace('ns3', 'http://www.garmin.com/xmlschemas/TrackPointExtension/v1');
 
 				$trkpts = $trk->xpath('//trkpt | //a:trkpt | //b:trkpt');
-				
+
 				$lastLat = 0;
 				$lastLon = 0;
 				$lastEle = 0;
@@ -249,7 +249,7 @@
 				//$dist = 0;
 				$lastOffset = 0;
 				$speedBuffer = array();
-			
+
 				foreach($trkpts as $trkpt)
 				{
 
@@ -264,8 +264,8 @@
 					$grade = 0;
 
 					if (isset($trkpt->extensions))
-					{				
-						
+					{
+
 						$arr = json_decode( json_encode($trkpt->extensions) , 1);
 
 						if (isset($arr['ns3:TrackPointExtension']))
@@ -273,16 +273,16 @@
 							$tpe = $arr['ns3:TrackPointExtension'];
 							$hr =    @$tpe["ns3:hr"];
 							$atemp = @$tpe["ns3:atemp"];
-							$cad =   @$tpe["ns3:cad"];			
+							$cad =   @$tpe["ns3:cad"];
 						}
 						else if (isset($arr['TrackPointExtension']))
 						{
 							$tpe = $arr['TrackPointExtension'];
 							$hr =    @$tpe["hr"];
 							$atemp = @$tpe["atemp"];
-							$cad =   @$tpe["cad"];							
+							$cad =   @$tpe["cad"];
 						}
-						
+
 					}
 
 					if ($lastLat == 0 && $lastLon == 0)
@@ -299,10 +299,10 @@
 						array_push($points->atemp,    	(float)$atemp);
 						array_push($points->cad,   		(float)$cad);
 						array_push($points->grade,   	$grade);
-						
+
 						$lastLat=$lat;
 						$lastLon=$lon;
-						$lastEle=$ele;				
+						$lastEle=$ele;
 						$lastTime=$time;
 					}
 					else
@@ -310,9 +310,9 @@
 						//Normal Case
 						$offset = calculateDistance((float)$lat, (float)$lon, (float)$ele, (float)$lastLat, (float)$lastLon, (float)$lastEle, $distancetype);
 						$dist = $dist + $offset;
-						
+
 						$points->totalLength = $dist;
-						
+
 						if ($speed == 0)
 						{
 							$datediff = (float)my_date_diff($lastTime,$time);
@@ -321,12 +321,12 @@
 								$speed = $offset / $datediff;
 							}
 						}
-						
+
 						if ($ele != 0 && $lastEle != 0)
 						{
-						
+
 							$deltaEle = (float)($ele - $lastEle);
-						
+
 							if ((float)$ele > (float)$lastEle)
 							{
 								$points->totalEleUp += $deltaEle;
@@ -335,28 +335,28 @@
 							{
 								$points->totalEleDown += $deltaEle;
 							}
-							
+
 							$grade = $deltaEle / $offset * 100;
-							
+
 						}
-						
+
 						array_push($speedBuffer, $speed);
-						
+
 						if (((float) $offset + (float) $lastOffset) > $gpxOffset)
 						{
 							//Bigger Offset -> write coordinate
 							$avgSpeed = 0;
-							
+
 							foreach($speedBuffer as $s)
-							{ 
+							{
 								$avgSpeed += $s;
 							}
-							
+
 							$avgSpeed = $avgSpeed / count($speedBuffer);
 							$speedBuffer = array();
-							
+
 							$lastOffset=0;
-							
+
 							array_push($points->dt,    strtotime($time));
 							array_push($points->lat,   (float)$lat );
 							array_push($points->lon,   (float)$lon );
@@ -367,7 +367,7 @@
 							array_push($points->atemp,	$atemp);
 							array_push($points->cad,	$cad);
 							array_push($points->grade, (float)round($grade, 2) );
-							
+
 						}
 						else
 						{
@@ -381,7 +381,7 @@
 					$lastTime=$time;
 
 				}
-				
+
 				array_push($points->dt,  null);
 				array_push($points->lat,  null);
 				array_push($points->lon,  null);
@@ -392,15 +392,15 @@
 				array_push($points->atemp, null);
 				array_push($points->cad, null);
 				array_push($points->grade, null);
-				
-				unset($trkpts);				
-			
+
+				unset($trkpts);
+
 			}
 
 			unset($nodes);
-			
+
 			try {
-			
+
 				array_pop($points->dt,  null);
 				array_pop($points->lat,  null);
 				array_pop($points->lon,  null);
@@ -411,7 +411,7 @@
 				array_pop($points->atemp, null);
 				array_pop($points->cad, null);
 				array_pop($points->grade, null);
-			
+
 				$_time = array_filter($points->dt);
 				$_ele = array_filter($points->ele);
 				$_dist = array_filter($points->dist);
@@ -424,43 +424,43 @@
 				// Calculating Average Speed
 				$_speed = array_filter($points->speed);
 				$points->avgSpeed = array_sum($_speed) / count($_speed);
-				
+
 				// Calculating Average Cadence
                 $_cad = array_filter($points->cad);
 				$points->avgCad = (float)round(array_sum($_cad) / count($_cad), 0);
-				
+
 				// Calculating Average Heart Rate
                 $_hr = array_filter($points->hr);
 				$points->avgHr = (float)round(array_sum($_hr) / count($_hr), 0);
-				
+
 				// Calculating Average Temperature
                 $_temp = array_filter($points->atemp);
 				$points->avgTemp = (float)round(array_sum($_temp) / count($_temp), 1);
-				
+
 			} catch (Exception $e) { }
-		
+
 		}
 		else
 		{
-		
+
 			// gpx garmin case
 			$gpx->registerXPathNamespace('gpxx', 'http://www.garmin.com/xmlschemas/GpxExtensions/v3');
-			
+
 			$nodes = $gpx->xpath('//gpxx:rpt');
-		
-			if ( count($nodes) > 0 )	
+
+			if ( count($nodes) > 0 )
 			{
-			
+
 				$lastLat = 0;
 				$lastLon = 0;
 				$lastEle = 0;
 				$dist = 0;
 				$lastOffset = 0;
-			
+
 				// Garmin case
 				foreach($nodes as $rpt)
-				{ 
-				
+				{
+
 					$lat = $rpt['lat'];
 					$lon = $rpt['lon'];
 					if ($lastLat == 0 && $lastLon == 0)
@@ -491,7 +491,7 @@
 							array_push($points->lon,   (float)$lon );
 							array_push($points->ele,   0 );
 							array_push($points->dist,  0 );
-							array_push($points->speed, 0 );	
+							array_push($points->speed, 0 );
 							array_push($points->hr,    0 );
 							array_push($points->atemp, 0 );
 							array_push($points->cad,   0 );
@@ -507,27 +507,27 @@
 					$lastLon=$lon;
 				}
 				unset($nodes);
-			
+
 			}
 			else
 			{
-			
+
 				//gpx strange case
 
 				$nodes = $gpx->xpath('//rtept | //a:rtept | //b:rtept');
 				if ( count($nodes) > 0 )
 				{
-				
+
 					$lastLat = 0;
 					$lastLon = 0;
 					$lastEle = 0;
 					$dist = 0;
 					$lastOffset = 0;
-				
+
 					// Garmin case
 					foreach($nodes as $rtept)
-					{ 
-					
+					{
+
 						$lat = $rtept['lat'];
 						$lon = $rtept['lon'];
 						if ($lastLat == 0 && $lastLon == 0)
@@ -558,7 +558,7 @@
 								array_push($points->lon,   (float)$lon );
 								array_push($points->ele,   0 );
 								array_push($points->dist,  0 );
-								array_push($points->speed, 0 );	
+								array_push($points->speed, 0 );
 								array_push($points->hr,    0 );
 								array_push($points->atemp, 0 );
 								array_push($points->cad,   0 );
@@ -574,35 +574,35 @@
 						$lastLon=$lon;
 					}
 					unset($nodes);
-					
+
 				}
 
 			}
-		
+
 		}
-		
+
 		unset($gpx);
 		return $points;
-	}	
-	
+	}
+
 	function wpgpxmaps_getWayPoints($gpxPath)
 	{
 		$points = array();
 		if (file_exists($gpxPath))
 		{
 			try {
-				$gpx = simplexml_load_file($gpxPath);	    
+				$gpx = simplexml_load_file($gpxPath);
 			} catch (Exception $e) {
 				echo "WP GPX Maps Error: Cant parse xml file " . $gpxPath;
 				return $points;
 			}
-		
+
 			$gpx->registerXPathNamespace('a', 'http://www.topografix.com/GPX/1/0');
 			$gpx->registerXPathNamespace('b', 'http://www.topografix.com/GPX/1/1');
 			$nodes = $gpx->xpath('//wpt | //a:wpt | //b:wpt');
 			global $wpdb;
-			
-			if ( count($nodes) > 0 )	
+
+			if ( count($nodes) > 0 )
 			{
 				// normal case
 				foreach($nodes as $wpt)
@@ -616,7 +616,7 @@
 					$sym  = (string) $wpt->sym;
 					$type = (string) $wpt->type;
 					$img  = '';
-					
+
 					if ($sym)
 					{
 						$img_name = 'map-marker-' . $sym;
@@ -626,7 +626,7 @@
 							$img = wp_get_attachment_url($img_id);
 						}
 					}
-					
+
 					array_push($points, array(
 						"lat"  => (float)$lat,
 						"lon"  => (float)$lon,
@@ -643,15 +643,15 @@
 		}
 		return $points;
 	}
-	
+
 	function toRadians($degrees)
 	{
 		return (float)($degrees * 3.1415926535897932385 / 180);
 	}
-	
+
 	function calculateDistance($lat1,$lon1,$ele1,$lat2,$lon2,$ele2,$distancetype)
 	{
-	
+
 		if ($distancetype == '2') // climb
 		{
 			return (float)$ele1 - (float)$ele2;
@@ -663,7 +663,7 @@
 			//Distance in meters
 			$a = (float) ( (float)$alpha * (float)$alpha) +  (float) ( (float)cos( (float)toRadians($lat1)) * (float)cos( (float)toRadians($lat2)) * (float)$beta * (float)$beta );
 			$dist = 2 * 6369628.75 * (float)atan2((float)sqrt((float)$a), (float)sqrt(1 - (float) $a));
-			return (float)sqrt((float)pow((float)$dist, 2) + pow((float) $lat1 - (float)$lat2, 2));	
+			return (float)sqrt((float)pow((float)$dist, 2) + pow((float) $lat1 - (float)$lat2, 2));
 		}
 		else // normal
 		{
@@ -672,23 +672,23 @@
 			//Distance in meters
 			$a = (float) ( (float)$alpha * (float)$alpha) +  (float) ( (float)cos( (float)toRadians($lat1)) * (float)cos( (float)toRadians($lat2)) * (float)$beta * (float)$beta );
 			$dist = 2 * 6369628.75 * (float)atan2((float)sqrt((float)$a), (float)sqrt(1 - (float) $a));
-			$d = (float)sqrt((float)pow((float)$dist, 2) + pow((float) $lat1 - (float)$lat2, 2));	
+			$d = (float)sqrt((float)pow((float)$dist, 2) + pow((float) $lat1 - (float)$lat2, 2));
 			return sqrt((float)pow((float)$ele1-(float)$ele2,2)+(float)pow((float)$d,2));
 		}
 
 	}
-	
+
 	function my_date_diff($old_date, $new_date) {
-	
+
 		$t1 = strtotime($new_date);
 		$t2 = strtotime($old_date);
-		
+
 		// milliceconds fix
 		$t1 += date_getDecimals($new_date);
 		$t2 += date_getDecimals($old_date);
-	
+
 		$offset = (float)($t1 - $t2);
-	  	  
+
 	  return $offset;
 	}
 
@@ -705,5 +705,5 @@
 	}
 
 
-	
+
 ?>

--- a/wp-gpx-maps_utils_nggallery.php
+++ b/wp-gpx-maps_utils_nggallery.php
@@ -1,149 +1,295 @@
-<?php
-
-	function wpgpxmaps_isNGGalleryActive() {
-		if (!function_exists('is_plugin_active')) {
-			require_once(wp_gpx_maps_sitePath() . '/wp-admin/includes/plugin.php');
-		}
-		return is_plugin_active("nextgen-gallery/nggallery.php");
-	}
-	
-	function wpgpxmaps_isNGGalleryProActive() {
-		if (!function_exists('is_plugin_active')) {
-			require_once(wp_gpx_maps_sitePath() . '/wp-admin/includes/plugin.php');
-		}
-		return is_plugin_active("nextgen-gallery-pro/nggallery-pro.php");
-	}
-	
-
-	function getNGGalleryImages($ngGalleries, $ngImages, $dt, $lat, $lon, $dtoffset, &$error)
-	{
-	
-		$result = array();
-		$galids = explode(',', $ngGalleries);
-		$imgids = explode(',', $ngImages);
-		
-		if (!wpgpxmaps_isNGGalleryActive())
-			return '';
-		try {
-
-			$pictures = array();
-			foreach ($galids as $g) {						
-				$pictures = array_merge($pictures, nggdb::get_gallery($g));
-			}
-			foreach ($imgids as $i) {
-				array_push($pictures, nggdb::find_image($i));
-			}
-			
-			// print_r ($pictures);
-			
-			foreach ($pictures as $p) {
-			
-				$item = array();
-				$item["data"] = $p->thumbHTML;
-				
-				if (is_callable('exif_read_data'))
-				{
-					$exif = @exif_read_data($p->imagePath);	
-					if ($exif !== false)
-					{
-						$item["lon"] = getExifGps($exif["GPSLongitude"], $exif['GPSLongitudeRef']);
-						$item["lat"] = getExifGps($exif["GPSLatitude"], $exif['GPSLatitudeRef']);
-						if (($item["lat"] != 0) || ($item["lon"] != 0)) 
-						{
-							$result[] = $item;
-						}
-						else if (isset($p->imagedate))
-						{
-							$_dt = strtotime($p->imagedate) + $dtoffset;
-							$_item = findItemCoordinate($_dt, $dt, $lat, $lon);
-							if ($_item != null)
-							{
-								$item["lat"] = $_item["lat"];
-								$item["lon"] = $_item["lon"];
-								$result[] = $item;
-							}
-						}
-					}
-				}
-				else
-				{
-					$error .= "Sorry, <a href='http://php.net/manual/en/function.exif-read-data.php' target='_blank' >exif_read_data</a> function not found! check your hosting..<br />";
-				}
-			}
-			
-
-/* START FIX NEXT GEN GALLERY 2.x */
-
-			if ( class_exists("C_Component_Registry") )
-			{
-
-				$renderer  = C_Component_Registry::get_instance()->get_utility('I_Displayed_Gallery_Renderer');
-				$params['gallery_ids']     = $ngGalleries;
-				$params['image_ids']       = $ngImages;
-				$params['display_type']    = NEXTGEN_GALLERY_BASIC_THUMBNAILS;
-				$params['images_per_page'] = 999;
-				// also add js references to get the gallery working
-				$dummy = $renderer->display_images($params, $inner_content);
-					
-	/* START FIX NEXT GEN GALLERY PRO */	
-
-				if (preg_match("/data-nplmodal-gallery-id=[\"'](.*?)[\"']/", $dummy, $m))
-				{
-					$galid = $m[1];
-					if ($galid)
-					{
-						for($i = 0; $i < count($result); ++$i) 
-						{
-							$result[$i]["data"] = str_replace("%PRO_LIGHTBOX_GALLERY_ID%", $galid, $result[$i]["data"]);
-						}
-					}
-				}
-	/* END FIX NEXT GEN GALLERY PRO */
-			}
-
-/* END FIX NEXT GEN GALLERY 2.x */
-			
-		} catch (Exception $e) {
-			$error .= 'Error When Retrieving NextGen Gallery galleries/images: $e <br />';
-		}
-
-		return $result;
-	}
-	
-	function findItemCoordinate($imgdt, $dt, $lat, $lon)
-	{
-		foreach(array_keys($dt) as $i) 
-		{
-			if ($i!=0 && $imgdt >= $dt[$i-1] && $imgdt <= $dt[$i])
-			{
-				if ($lat[$i] != 0 && $lon[$i] != 0)
-					return array( "lat" => $lat[$i], "lon" => $lon[$i] );
-			}
-		}
-		return null;
-	}
-	
-	function getExifGps($exifCoord, $hemi) 
-	{
-		$degrees = count($exifCoord) > 0 ? gps2Num($exifCoord[0]) : 0;
-		$minutes = count($exifCoord) > 1 ? gps2Num($exifCoord[1]) : 0;
-		$seconds = count($exifCoord) > 2 ? gps2Num($exifCoord[2]) : 0;
-		$flip = ($hemi == 'W' or $hemi == 'S') ? -1 : 1;
-		return $flip * ($degrees + $minutes / 60 + $seconds / 3600);
-	}
-
-	function gps2Num($coordPart) 
-	{
-		$parts = explode('/', $coordPart);
-		if (count($parts) <= 0)
-			return 0;
-		if (count($parts) == 1)
-			return $parts[0];		
-		$lat = floatval($parts[0]);
-		$lon = floatval($parts[1]);
-		if ($lon == 0)
-			return $lat;
-		return $lat / $lon;
-	}
-
+<?php
+
+
+
+	function wpgpxmaps_isNGGalleryActive() {
+
+		if (!function_exists('is_plugin_active')) {
+
+			require_once(wp_gpx_maps_sitePath() . '/wp-admin/includes/plugin.php');
+
+		}
+
+		return is_plugin_active("nextgen-gallery/nggallery.php");
+
+	}
+
+
+
+	function wpgpxmaps_isNGGalleryProActive() {
+
+		if (!function_exists('is_plugin_active')) {
+
+			require_once(wp_gpx_maps_sitePath() . '/wp-admin/includes/plugin.php');
+
+		}
+
+		return is_plugin_active("nextgen-gallery-pro/nggallery-pro.php");
+
+	}
+
+
+
+	function getNGGalleryImages($ngGalleries, $ngImages, $dt, $lat, $lon, $dtoffset, &$error)
+
+	{
+
+
+
+		$result = array();
+
+		$galids = explode(',', $ngGalleries);
+
+		$imgids = explode(',', $ngImages);
+
+
+
+		if (!wpgpxmaps_isNGGalleryActive())
+
+			return '';
+
+		try {
+
+
+
+			$pictures = array();
+
+			foreach ($galids as $g) {
+
+				$pictures = array_merge($pictures, nggdb::get_gallery($g));
+
+			}
+
+			foreach ($imgids as $i) {
+
+				array_push($pictures, nggdb::find_image($i));
+
+			}
+
+
+
+			// print_r ($pictures);
+
+
+
+			foreach ($pictures as $p) {
+
+
+
+				$item = array();
+
+				$item["data"] = $p->thumbHTML;
+
+
+
+				if (is_callable('exif_read_data'))
+
+				{
+
+					$exif = @exif_read_data($p->imagePath);
+
+					if ($exif !== false)
+
+					{
+
+						$item["lon"] = getExifGps($exif["GPSLongitude"], $exif['GPSLongitudeRef']);
+
+						$item["lat"] = getExifGps($exif["GPSLatitude"], $exif['GPSLatitudeRef']);
+
+						if (($item["lat"] != 0) || ($item["lon"] != 0))
+
+						{
+
+							$result[] = $item;
+
+						}
+
+						else if (isset($p->imagedate))
+
+						{
+
+							$_dt = strtotime($p->imagedate) + $dtoffset;
+
+							$_item = findItemCoordinate($_dt, $dt, $lat, $lon);
+
+							if ($_item != null)
+
+							{
+
+								$item["lat"] = $_item["lat"];
+
+								$item["lon"] = $_item["lon"];
+
+								$result[] = $item;
+
+							}
+
+						}
+
+					}
+
+				}
+
+				else
+
+				{
+
+					$error .= "Sorry, <a href='http://php.net/manual/en/function.exif-read-data.php' target='_blank' >exif_read_data</a> function not found! check your hosting..<br />";
+
+				}
+
+			}
+
+
+
+
+
+/* START FIX NEXT GEN GALLERY 2.x */
+
+
+
+			if ( class_exists("C_Component_Registry") )
+
+			{
+
+
+
+				$renderer  = C_Component_Registry::get_instance()->get_utility('I_Displayed_Gallery_Renderer');
+
+				$params['gallery_ids']     = $ngGalleries;
+
+				$params['image_ids']       = $ngImages;
+
+				$params['display_type']    = NEXTGEN_GALLERY_BASIC_THUMBNAILS;
+
+				$params['images_per_page'] = 999;
+
+				// also add js references to get the gallery working
+
+				$dummy = $renderer->display_images($params, $inner_content);
+
+
+
+	/* START FIX NEXT GEN GALLERY PRO */
+
+
+
+				if (preg_match("/data-nplmodal-gallery-id=[\"'](.*?)[\"']/", $dummy, $m))
+
+				{
+
+					$galid = $m[1];
+
+					if ($galid)
+
+					{
+
+						for($i = 0; $i < count($result); ++$i)
+
+						{
+
+							$result[$i]["data"] = str_replace("%PRO_LIGHTBOX_GALLERY_ID%", $galid, $result[$i]["data"]);
+
+						}
+
+					}
+
+				}
+
+	/* END FIX NEXT GEN GALLERY PRO */
+
+			}
+
+
+
+/* END FIX NEXT GEN GALLERY 2.x */
+
+
+
+		} catch (Exception $e) {
+
+			$error .= 'Error When Retrieving NextGen Gallery galleries/images: $e <br />';
+
+		}
+
+
+
+		return $result;
+
+	}
+
+
+
+	function findItemCoordinate($imgdt, $dt, $lat, $lon)
+
+	{
+
+		foreach(array_keys($dt) as $i)
+
+		{
+
+			if ($i!=0 && $imgdt >= $dt[$i-1] && $imgdt <= $dt[$i])
+
+			{
+
+				if ($lat[$i] != 0 && $lon[$i] != 0)
+
+					return array( "lat" => $lat[$i], "lon" => $lon[$i] );
+
+			}
+
+		}
+
+		return null;
+
+	}
+
+
+
+	function getExifGps($exifCoord, $hemi)
+
+	{
+
+		$degrees = count($exifCoord) > 0 ? gps2Num($exifCoord[0]) : 0;
+
+		$minutes = count($exifCoord) > 1 ? gps2Num($exifCoord[1]) : 0;
+
+		$seconds = count($exifCoord) > 2 ? gps2Num($exifCoord[2]) : 0;
+
+		$flip = ($hemi == 'W' or $hemi == 'S') ? -1 : 1;
+
+		return $flip * ($degrees + $minutes / 60 + $seconds / 3600);
+
+	}
+
+
+
+	function gps2Num($coordPart)
+
+	{
+
+		$parts = explode('/', $coordPart);
+
+		if (count($parts) <= 0)
+
+			return 0;
+
+		if (count($parts) == 1)
+
+			return $parts[0];
+
+		$lat = floatval($parts[0]);
+
+		$lon = floatval($parts[1]);
+
+		if ($lon == 0)
+
+			return $lat;
+
+		return $lat / $lon;
+
+	}
+
+
+
 ?>


### PR DESCRIPTION
I know it's a bunch of changes

- Update to official version 1.6.07
- fixed errors in translatable strings (wrong textdomain, WP Coding Standards
- made textstrings in backend translatable
- error message for gpx and cache folder have now WP-Style
- notice message for file and cache have now WP-Style
- removed many whitespace