### PR TITLE
Update Tested WordPress up to.5.2.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: bastianonm, Stephan Klein, Michel Selerin
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8VHWLRW6JBTML
 Tags: maps, gpx, gps, graph, chart, leaflet, track, garmin, image, nextgen-gallery, nextgen, exif, OpenStreetMap, OpenCycleMap, Hike&Bike, heart rate, heartrate, cadence
 Requires at least: 2.0.0
-Tested up to: 4.9.8
+Tested up to: 5.2.0
 Stable tag: 1.7.00
 
 Draws a gpx track with altitude graph. You can also display your nextgen gallery images in the map.


### PR DESCRIPTION
The version should be raised. The plugin already has a yellow note on the WordPress page that may be incompatible with new WordPress versions.