### PR TITLE
little text adjustments + 2 bugs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ Supported GPX namespaces are:
 
 Thanks to: <a href="http://www.securcube.net/" target="_blank" rel="noopener noreferrer">www.securcube.net</a>, <a href="http://www.devfarm.it/" target="_blank" rel="noopener noreferrer">www.devfarm.it</a>
 
-Icons made by <a href="https://www.freepik.com/?__hstc=57440181.104a2a973b6d66e5ac5f75fcf2d4ef9e.1559729255492.1559729255492.1559803759717.2&__hssc=57440181.7.1559803759717&__hsfp=1353452017" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" 			    title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" 			    title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a>
+Icons made by <a href="https://www.freepik.com/" target="_blank" rel="noopener noreferrer">Freepik</a> from <a href="https://www.flaticon.com/" target="_blank" rel="noopener noreferrer">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank" rel="noopener noreferrer">Creative Commons BY 3.0</a>
 
 == Installation ==
 

--- a/wp-gpx-maps_admin_settings.php
+++ b/wp-gpx-maps_admin_settings.php
@@ -474,7 +474,7 @@
 	<table class="form-table">
 
 		<tr>
-			<th scope="row"><?php _e( 'Altitude', 'wp-gpx-maps' ); ?></th>
+			<th scope="row"><?php _e( 'Altitude:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input type="checkbox" <?php if ( $showEle == true ){ echo( 'checked' ); } ?> onchange="wpgpxmaps_show_elevation.value = this.checked" onload="wpgpxmaps_show_elevation.value = this.checked" />
 				<i>
@@ -683,9 +683,9 @@
 				</i>
 			</td>
 		</tr>
-		
+
 		<tr>
-			<th scope="row"><?php _e( 'User upload', 'wp-gpx-maps'); ?></th>
+			<th scope="row"><?php _e( 'User upload:', 'wp-gpx-maps' ); ?></th>
 			<td>
 				<input name="wpgpxmaps_allow_users_view" type="checkbox" value="true" onchange="this.value = (this.checked)" <?php if ( $allow_users_upload === "true" ) { echo( 'checked' ); } ?>>
 					<i>

--- a/wp-gpx-maps_help.php
+++ b/wp-gpx-maps_help.php
@@ -14,7 +14,7 @@
 		_e( '2. Method: Upload the GPX file via FTP to your upload folder:', 'wp-gpx-maps' );
 		echo ' ';
 	?>
-	<span class="code"><strong> <?php echo $relativeGpxPath; ?> </strong></span>
+	<code><strong> <?php echo $relativeGpxPath; ?> </strong></code>
 </p>
 <p>
 	<strong><?php _e( 'How can I use the GPX files?', 'wp-gpx-maps' ); ?></strong>
@@ -28,7 +28,7 @@
 		_e( 'You can manually set the relative path to your GPX file. Please use this scheme:', 'wp-gpx-maps' );
 		echo ' ';
 	?>
-		<span class="code"><strong>[sgpx gpx="<?php echo $relativeGpxPath; ?>yourgpxfile.gpx"]</strong></span>
+		<code><strong>[sgpx gpx="<?php echo $relativeGpxPath; ?>yourgpxfile.gpx"]</strong></code>
 </p>
 <p>
 	<strong><?php _e( 'Can I also integrate GPX files from other sites?', 'wp-gpx-maps' ); ?></strong>
@@ -39,7 +39,7 @@
 		_e( 'Yes, it&#8217s possible. Please use this scheme:', 'wp-gpx-maps' );
 		echo ' ';
 	?>
-	<span class="code"><strong>[sgpx gpx="http://www.someone.com/somewhere/somefile.gpx"]</strong></span>
+	<code><strong>[sgpx gpx="http://www.someone.com/somewhere/somefile.gpx"]</strong></code>
 </p>
 <p>
 	<strong><?php _e( 'Can I change the attributes for each GPX shortcode?', 'wp-gpx-maps' ); ?></strong>
@@ -53,7 +53,7 @@
 		_e( 'The Full set of optional attributes can be found below. Please use this scheme:', 'wp-gpx-maps' );
 		echo ' ';
 	?>
-		<span class="code"><strong>[sgpx gpx="<?php echo $relativeGpxPath; ?>yourgpxfile.gpx &lt; <?php _e( 'read below all the optional attributes', 'wp-gpx-maps' ); ?> &gt;"]</strong></span>
+		<code><strong>[sgpx gpx="<?php echo $relativeGpxPath; ?>yourgpxfile.gpx &lt; <?php _e( 'read below all the optional attributes', 'wp-gpx-maps' ); ?> &gt;"]</strong></code>
 </p>
 
 <br />
@@ -70,7 +70,7 @@
 		<tr>
 		<td>gpx</td>
 		<td><?php _e( 'relative path to the GPX file', 'wp-gpx-maps' ); ?></td>
-		<td><span class="code"><strong>gpx="<?php echo $relativeGpxPath; ?>yourgpxfile.gpx"</strong></span></td>
+		<td><code><strong>gpx="<?php echo $relativeGpxPath; ?>yourgpxfile.gpx"</strong></code></td>
 	</tr>
 	<tr>
 		<td>width</td>


### PR DESCRIPTION
- added in settings 2 missed ":"
- in help tab added color for phats

I have found 2 more errors:
in settings tab: is the new function wpgpxmaps_allow_users_view, but the text say is "User upload"
in tab tracks: the downloadlink works, but the gpx file is opened in the browser right away, there is no question if i want to download or open it