### PR TITLE
Fixed WPCS space messages

### DIFF
--- a/css/admin-style.css
+++ b/css/admin-style.css
@@ -17,7 +17,7 @@
 /**
  * 2.0 Tab: Tracks
  */
- #table tbody tr:hover {
+#table tbody tr:hover {
 	background: #eee;
 }
 

--- a/css/bootstrap-table.css
+++ b/css/bootstrap-table.css
@@ -5,10 +5,10 @@
  */
 
 .bootstrap-table .table {
-    margin-bottom: 0 !important;
-    border-bottom: 1px solid #dddddd;
-    border-collapse: collapse !important;
-    border-radius: 1px;
+	margin-bottom: 0 !important;
+	border-bottom: 1px solid #ddd;
+	border-radius: 1px;
+	border-collapse: collapse !important;
 }
 
 .bootstrap-table .table:not(.table-condensed),
@@ -17,321 +17,323 @@
 .bootstrap-table .table:not(.table-condensed) > thead > tr > td,
 .bootstrap-table .table:not(.table-condensed) > tbody > tr > td,
 .bootstrap-table .table:not(.table-condensed) > tfoot > tr > td {
-    padding: 8px;
+	padding: 8px;
 }
 
 .bootstrap-table .table.table-no-bordered > thead > tr > th {
-    border-top: none;
+	border-top: none;
 }
 
 .bootstrap-table .table.table-no-bordered > thead > tr > th,
 .bootstrap-table .table.table-no-bordered > tbody > tr > td {
-    border-right: 2px solid transparent;
+	border-right: 2px solid transparent;
 }
 
 .bootstrap-table .table.table-no-bordered > tbody > tr > td:last-child {
-    border-right: none;
+	border-right: none;
 }
 
 .fixed-table-container {
-    position: relative;
-    clear: both;
-    border: 1px solid #dddddd;
-    border-radius: 4px;
-    -webkit-border-radius: 4px;
-    -moz-border-radius: 4px;
+	clear: both;
+	position: relative;
+	border: 1px solid #ddd;
+	-webkit-border-radius: 4px;
+	-moz-border-radius: 4px;
+	border-radius: 4px;
 }
 
 .fixed-table-container.table-no-bordered {
-    border: 1px solid transparent;
+	border: 1px solid transparent;
 }
 
 .fixed-table-footer,
 .fixed-table-header {
-    overflow: hidden;
+	overflow: hidden;
 }
 
 .fixed-table-footer {
-    border-top: 1px solid #dddddd;
+	border-top: 1px solid #ddd;
 }
 
 .fixed-table-body {
-    overflow-x: auto;
-    overflow-y: auto;
-    height: 100%;
+	overflow-x: auto;
+	overflow-y: auto;
+	height: 100%;
 }
 
 .fixed-table-container table {
-    width: 100%;
+	width: 100%;
 }
 
 .fixed-table-container thead th {
-    height: 0;
-    padding: 0;
-    margin: 0;
-    border-left: 1px solid #dddddd;
+	height: 0;
+	margin: 0;
+	padding: 0;
+	border-left: 1px solid #ddd;
 }
 
 .fixed-table-container thead th:focus {
-    outline: 0 solid transparent;
+	outline: 0 solid transparent;
 }
 
 .fixed-table-container thead th:first-child:not([data-not-first-th]) {
-    border-left: none;
-    border-top-left-radius: 4px;
-    -webkit-border-top-left-radius: 4px;
-    -moz-border-radius-topleft: 4px;
+	border-left: none;
+	-webkit-border-top-left-radius: 4px;
+	-moz-border-radius-topleft: 4px;
+	border-top-left-radius: 4px;
 }
 
 .fixed-table-container thead th .th-inner,
 .fixed-table-container tbody td .th-inner {
-    padding: 8px;
-    line-height: 24px;
-    vertical-align: top;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+	overflow: hidden;
+	padding: 8px;
+	line-height: 24px;
+	vertical-align: top;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .fixed-table-container thead th .sortable {
-    cursor: pointer;
-    background-position: right;
-    background-repeat: no-repeat;
-    padding-right: 30px;
+	padding-right: 30px;
+	background-repeat: no-repeat;
+	background-position: right;
+	cursor: pointer;
 }
 
 .fixed-table-container thead th .both {
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAQAAADYWf5HAAAAkElEQVQoz7X QMQ5AQBCF4dWQSJxC5wwax1Cq1e7BAdxD5SL+Tq/QCM1oNiJidwox0355mXnG/DrEtIQ6azioNZQxI0ykPhTQIwhCR+BmBYtlK7kLJYwWCcJA9M4qdrZrd8pPjZWPtOqdRQy320YSV17OatFC4euts6z39GYMKRPCTKY9UnPQ6P+GtMRfGtPnBCiqhAeJPmkqAAAAAElFTkSuQmCC');
+	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAQAAADYWf5HAAAAkElEQVQoz7X QMQ5AQBCF4dWQSJxC5wwax1Cq1e7BAdxD5SL+Tq/QCM1oNiJidwox0355mXnG/DrEtIQ6azioNZQxI0ykPhTQIwhCR+BmBYtlK7kLJYwWCcJA9M4qdrZrd8pPjZWPtOqdRQy320YSV17OatFC4euts6z39GYMKRPCTKY9UnPQ6P+GtMRfGtPnBCiqhAeJPmkqAAAAAElFTkSuQmCC');
 }
 
 .fixed-table-container thead th .asc {
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAZ0lEQVQ4y2NgGLKgquEuFxBPAGI2ahhWCsS/gDibUoO0gPgxEP8H4ttArEyuQYxAPBdqEAxPBImTY5gjEL9DM+wTENuQahAvEO9DMwiGdwAxOymGJQLxTyD+jgWDxCMZRsEoGAVoAADeemwtPcZI2wAAAABJRU5ErkJggg==');
+	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAZ0lEQVQ4y2NgGLKgquEuFxBPAGI2ahhWCsS/gDibUoO0gPgxEP8H4ttArEyuQYxAPBdqEAxPBImTY5gjEL9DM+wTENuQahAvEO9DMwiGdwAxOymGJQLxTyD+jgWDxCMZRsEoGAVoAADeemwtPcZI2wAAAABJRU5ErkJggg==');
 }
 
 .fixed-table-container thead th .desc {
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAZUlEQVQ4y2NgGAWjYBSggaqGu5FA/BOIv2PBIPFEUgxjB+IdQPwfC94HxLykus4GiD+hGfQOiB3J8SojEE9EM2wuSJzcsFMG4ttQgx4DsRalkZENxL+AuJQaMcsGxBOAmGvopk8AVz1sLZgg0bsAAAAASUVORK5CYII= ');
+	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAZUlEQVQ4y2NgGAWjYBSggaqGu5FA/BOIv2PBIPFEUgxjB+IdQPwfC94HxLykus4GiD+hGfQOiB3J8SojEE9EM2wuSJzcsFMG4ttQgx4DsRalkZENxL+AuJQaMcsGxBOAmGvopk8AVz1sLZgg0bsAAAAASUVORK5CYII= ');
 }
 
 .fixed-table-container th.detail {
-    width: 30px;
+	width: 30px;
 }
 
 .fixed-table-container tbody td {
-    border-left: 1px solid #dddddd;
+	border-left: 1px solid #ddd;
 }
 
 .fixed-table-container tbody tr:first-child td {
-    border-top: none;
+	border-top: none;
 }
 
 .fixed-table-container tbody td:first-child {
-    border-left: none;
+	border-left: none;
 }
 
 /* the same color with .active */
 .fixed-table-container tbody .selected td {
-    background-color: #f5f5f5;
+	background-color: #f5f5f5;
 }
 
 .fixed-table-container .bs-checkbox {
-    text-align: center;
+	text-align: center;
 }
 
 .fixed-table-container input[type="radio"],
 .fixed-table-container input[type="checkbox"] {
-    margin: 0 auto !important;
+	margin: 0 auto !important;
 }
 
 .fixed-table-container .no-records-found {
-    text-align: center;
+	text-align: center;
 }
 
 .fixed-table-pagination div.pagination,
 .fixed-table-pagination .pagination-detail {
-    margin-top: 10px;
-    margin-bottom: 10px;
+	margin-top: 10px;
+	margin-bottom: 10px;
 }
 
 .fixed-table-pagination div.pagination .pagination {
-    margin: 0;
+	margin: 0;
 }
 
 .fixed-table-pagination .pagination a {
-    padding: 6px 12px;
-    line-height: 1.428571429;
+	padding: 6px 12px;
+	line-height: 1.428571429;
 }
 
 .fixed-table-pagination ul.pagination li.page-intermediate a {
-    color:#c8c8c8;
+	color:#c8c8c8;
 }
 
 .fixed-table-pagination ul.pagination li.page-intermediate a:before {
-    content: '\2B05';
+	content: '\2B05';
 }
 
 .fixed-table-pagination ul.pagination li.page-intermediate a:after {
-    content: '\27A1';
+	content: '\27A1';
 }
 
 .fixed-table-pagination .pagination-info {
-    line-height: 34px;
-    margin-right: 5px;
+	margin-right: 5px;
+	line-height: 34px;
 }
 
 .fixed-table-pagination .btn-group {
-    position: relative;
-    display: inline-block;
-    vertical-align: middle;
+	display: inline-block;
+	position: relative;
+	vertical-align: middle;
 }
 
 .fixed-table-pagination .dropup .dropdown-menu {
-    margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .fixed-table-pagination .page-list {
-    display: inline-block;
+	display: inline-block;
 }
 
 .fixed-table-toolbar .columns-left {
-    margin-right: 5px;
+	margin-right: 5px;
 }
 
 .fixed-table-toolbar .columns-right {
-    margin-left: 5px;
+	margin-left: 5px;
 }
 
 .fixed-table-toolbar .columns label {
-    display: block;
-    padding: 3px 20px;
-    clear: both;
-    font-weight: normal;
-    line-height: 1.428571429;
+	display: block;
+	clear: both;
+	padding: 3px 20px;
+	font-weight: 400;
+	line-height: 1.428571429;
 }
 
 .fixed-table-toolbar .bs-bars,
 .fixed-table-toolbar .search,
 .fixed-table-toolbar .columns {
-    position: relative;
-    margin-top: 10px;
-    margin-bottom: 10px;
+	position: relative;
+	margin-top: 10px;
+	margin-bottom: 10px;
 }
 
 .fixed-table-pagination li.disabled a {
-    pointer-events: none;
-    cursor: default;
+	cursor: default;
+	pointer-events: none;
 }
 
 .fixed-table-loading {
-    display: none;
-    position: absolute;
-    top: 42px;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 99;
-    background-color: #fff;
-    text-align: center;
+	display: none;
+	position: absolute;
+	z-index: 99;
+	top: 42px;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background-color: #fff;
+	text-align: center;
 }
 
 .fixed-table-body .card-view .title {
-    font-weight: bold;
-    display: inline-block;
-    min-width: 30%;
-    text-align: left !important;
+	display: inline-block;
+	min-width: 30%;
+	font-weight: 700;
+	text-align: left !important;
 }
 
 /* support bootstrap 2 */
 .fixed-table-body thead th .th-inner {
-    box-sizing: border-box;
+	box-sizing: border-box;
 }
 
-.table th, .table td {
-    vertical-align: middle;
-    box-sizing: border-box;
+.table th,
+.table td {
+	box-sizing: border-box;
+	vertical-align: middle;
 }
 
 .fixed-table-toolbar .dropdown-menu {
-    text-align: left;
-    max-height: 300px;
-    overflow: auto;
+	overflow: auto;
+	max-height: 300px;
+	text-align: left;
 }
 
 .fixed-table-toolbar .btn-group > .btn-group {
-    display: inline-block;
-    margin-left: -1px !important;
+	display: inline-block;
+	margin-left: -1px !important;
 }
 
 .fixed-table-toolbar .btn-group > .btn-group > .btn {
-    border-radius: 0;
+	border-radius: 0;
 }
 
 .fixed-table-toolbar .btn-group > .btn-group:first-child > .btn {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+	border-top-left-radius: 4px;
+	border-bottom-left-radius: 4px;
 }
 
 .fixed-table-toolbar .btn-group > .btn-group:last-child > .btn {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+	border-top-right-radius: 4px;
+	border-bottom-right-radius: 4px;
 }
 
 .bootstrap-table .table > thead > tr > th {
-    vertical-align: bottom;
-    border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #ddd;
+	vertical-align: bottom;
 }
 
 .bootstrap-table .table > thead.thead-dark > tr > th {
-    border-bottom: 1px solid #212529;
+	border-bottom: 1px solid #212529;
 }
 
 /* support bootstrap 3 */
 .bootstrap-table .table thead > tr > th {
-    padding: 0;
-    margin: 0;
+	margin: 0;
+	padding: 0;
 }
 
 .bootstrap-table .fixed-table-footer tbody > tr > td {
-    padding: 0 !important;
+	padding: 0 !important;
 }
 
 .bootstrap-table .fixed-table-footer .table {
-    border-bottom: none;
-    border-radius: 0;
-    padding: 0 !important;
+	padding: 0 !important;
+	border-bottom: none;
+	border-radius: 0;
 }
 
 .bootstrap-table .pull-right .dropdown-menu {
-    right: 0;
-    left: auto;
+	right: 0;
+	left: auto;
 }
 
 /* calculate scrollbar width */
 p.fixed-table-scroll-inner {
-    width: 100%;
-    height: 200px;
+	width: 100%;
+	height: 200px;
 }
 
 div.fixed-table-scroll-outer {
-    top: 0;
-    left: 0;
-    visibility: hidden;
-    width: 200px;
-    height: 150px;
-    overflow: hidden;
+	visibility: hidden;
+	overflow: hidden;
+	top: 0;
+	left: 0;
+	width: 200px;
+	height: 150px;
 }
 
 /* for get correct heights  */
-.fixed-table-toolbar:after, .fixed-table-pagination:after {
-    content: "";
-    display: block;
-    clear: both;
+.fixed-table-toolbar:after,
+.fixed-table-pagination:after {
+	display: block;
+	clear: both;
+	content: "";
 }
 
 .bootstrap-table.fullscreen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 1050;
-    width: 100%!important;
-    background: #FFF;
+	position: fixed;
+	z-index: 1050;
+	top: 0;
+	left: 0;
+	width: 100% !important;
+	background: #fff;
 }

--- a/css/output-style.css
+++ b/css/output-style.css
@@ -41,8 +41,6 @@
 	line-height :120;
 }
 
-.wpgpxmaps .gmnoprint div:first-child { }
-
 .wpgpxmaps .wpgpxmaps_osm_footer {
 	position: absolute;
 	z-index: 999;

--- a/js/WP-GPX-Maps.js
+++ b/js/WP-GPX-Maps.js
@@ -11,26 +11,22 @@ var WPGPXMAPS = {
 
 	Utils: {
 
-		// In case of multiple polylines this function divide the points of each polyline.
+		/* In case of multiple polylines this function divide the points of each polyline. */
 		DividePolylinesPoints: function( mapData ) {
 
 			var lastCut = 0;
-
 			var result = [];
-
 			var _len = mapData.length;
 
 			for ( i = 0; i < _len; i++ ) {
-				if ( mapData[i] == null ) {
+				if ( null == mapData[i]) {
 					result.push( mapData.slice( lastCut == 0 ? 0 : lastCut + 1, i ) );
 					lastCut = i;
 				}
 			}
-
 			if ( ( _len - 1 ) != lastCut ) {
 				result.push( mapData.slice( lastCut ) );
 			}
-
 			return result;
 
 		},
@@ -43,30 +39,30 @@ var WPGPXMAPS = {
 			}
 		}
 
-
 	},
 
 	MapEngines: {
 
 		/* NOT WORKING AND TESTED! old code copy&paste */
 		GoogleMaps: function() {
+
+			var ngImageMarkers = [];
+
 			this.map = null,
 			this.EventSelectChart = null,
 			this.Polylines = [],
 			this.init = function( targetElement, mapType, scrollWheelZoom, ThunderforestApiKey ) {
-
 				var mapTypeIds = [];
 				for ( var type in google.maps.MapTypeId ) {
 					mapTypeIds.push( google.maps.MapTypeId[type]);
 				}
+
 				mapTypeIds.push( 'OSM1' );
 				mapTypeIds.push( 'OSM2' );
 				mapTypeIds.push( 'OSM3' );
 				mapTypeIds.push( 'OSM4' );
 				mapTypeIds.push( 'OSM5' );
 				mapTypeIds.push( 'OSM6' );
-
-				var ngImageMarkers = [];
 
 				switch ( mapType ) {
 					case 'TERRAIN': { mapType = google.maps.MapTypeId.TERRAIN; break;}
@@ -81,28 +77,30 @@ var WPGPXMAPS = {
 					default: { mapType = google.maps.MapTypeId.HYBRID; break;}
 				}
 
-				if ( mapType == 'TERRAIN' || mapType == 'SATELLITE' || mapType == 'ROADMAP' ) {
+				if ( 'TERRAIN' == mapType || 'SATELLITE' == mapType || 'ROADMAP' == mapType ) {
 
-					// google maps
+					// Google maps.
+
 				} else {
 
-					// Show OpenStreetMaps credits
+					// Show OpenStreetMaps credits.
+
 					$( el_osm_credits ).show();
 				}
 
 				this.map = new google.maps.Map( el_map, {
 					mapTypeId: mapType,
-					scrollwheel: ( zoomOnScrollWheel == 'true' ),
+					scrollwheel: ( 'true' == zoomOnScrollWheel ),
 					mapTypeControlOptions: {
 						style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
 						mapTypeIds: mapTypeIds
 					}
 				});
 
-
+				/* Map type: Open Street Mao */
 				this.map.mapTypes.set( 'OSM1', new google.maps.ImageMapType({
 					getTileUrl: function( coord, zoom ) {
-						return "https://tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + '.png';
+						return 'https://tile.openstreetmap.org/' + zoom + '/' + coord.x + '/' + coord.y + '.png';
 					},
 					tileSize: new google.maps.Size( 256, 256 ),
 					name: 'OSM',
@@ -110,27 +108,28 @@ var WPGPXMAPS = {
 					maxZoom: 18
 				}) );
 
-
+				/* Map type: Thunderforst - Open Cycle Map with API key or Open Cycle Map - Cycle */
 				this.map.mapTypes.set( 'OSM2', new google.maps.ImageMapType({
 					getTileUrl: function( coord, zoom ) {
 						if ( hasThunderforestApiKey ) {
-							return "https://a.tile.thunderforest.com/cycle/" + zoom + "/" + coord.x + "/" + coord.y + ".png?apikey=" + ThunderforestApiKey;
+							return 'https://a.tile.thunderforest.com/cycle/' + zoom + '/' + coord.x + '/' + coord.y + '.png?apikey=' + ThunderforestApiKey;
 						} else {
-							return "http://a.tile.opencyclemap.org/cycle/" + zoom + "/" + coord.x + "/" + coord.y + '.png';
+							return 'http://a.tile.opencyclemap.org/cycle/' + zoom + '/' + coord.x + '/' + coord.y + '.png';
 						}
 					},
 					tileSize: new google.maps.Size( 256, 256 ),
-					name: 'OCM',
-					alt: 'Open Cycle Map',
+					name: 'OCM-Cycl',
+					alt: 'Open Cycle Map - Cycle',
 					maxZoom: 18
 				}) );
 
+				/* Map type: Thunderforst - Transport with API key or Open Cycle Map - Transport */
 				this.map.mapTypes.set( 'OSM4', new google.maps.ImageMapType({
 					getTileUrl: function( coord, zoom ) {
 						if ( hasThunderforestApiKey ) {
-							return "https://a.tile.thunderforest.com/transport/" + zoom + "/" + coord.x + "/" + coord.y + ".png?apikey=" + ThunderforestApiKey;
+							return 'https://a.tile.thunderforest.com/transport/' + zoom + '/' + coord.x + '/' + coord.y + '.png?apikey=' + ThunderforestApiKey;
 						} else {
-							return "http://a.tile2.opencyclemap.org/transport/" + zoom + "/" + coord.x + "/" + coord.y + '.png';
+							return 'http://a.tile2.opencyclemap.org/transport/' + zoom + '/' + coord.x + '/' + coord.y + '.png';
 						}
 					},
 					tileSize: new google.maps.Size( 256, 256 ),
@@ -139,12 +138,13 @@ var WPGPXMAPS = {
 					maxZoom: 18
 				}) );
 
+				/* Map type: Thunderforst - Landscape with API key or Open Cycle Map - Landscape */
 				this.map.mapTypes.set( 'OSM5', new google.maps.ImageMapType({
 					getTileUrl: function( coord, zoom ) {
 						if ( hasThunderforestApiKey ) {
-							return "https://a.tile.thunderforest.com/landscape/" + zoom + "/" + coord.x + "/" + coord.y + ".png?apikey=" + ThunderforestApiKey;
+							return 'https://a.tile.thunderforest.com/landscape/' + zoom + '/' + coord.x + '/' + coord.y + '.png?apikey=' + ThunderforestApiKey;
 						} else {
-							return "http://a.tile3.opencyclemap.org/landscape/" + zoom + "/" + coord.x + "/" + coord.y + '.png';
+							return 'http://a.tile3.opencyclemap.org/landscape/' + zoom + '/' + coord.x + '/' + coord.y + '.png';
 						}
 					},
 					tileSize: new google.maps.Size( 256, 256 ),
@@ -153,9 +153,10 @@ var WPGPXMAPS = {
 					maxZoom: 18
 				}) );
 
+				/* Map type: MapToolKit - Terrain */
 				this.map.mapTypes.set( 'OSM6', new google.maps.ImageMapType({
 					getTileUrl: function( coord, zoom ) {
-						return "https://tile2.maptoolkit.net/terrain/" + zoom + "/" + coord.x + "/" + coord.y + '.png';
+						return 'https://tile2.maptoolkit.net/terrain/' + zoom + '/' + coord.x + '/' + coord.y + '.png';
 					},
 					tileSize: new google.maps.Size( 256, 256 ),
 					name: 'MTK-Terr',
@@ -173,7 +174,6 @@ var WPGPXMAPS = {
 				var color = 0;
 				for ( i = 0; i < mapData.length; i++ ) {
 					if ( mapData[i] == null ) {
-
 						var poly = new google.maps.Polyline({
 							path: points.slice( lastCut, i ),
 							strokeColor: color,
@@ -185,9 +185,10 @@ var WPGPXMAPS = {
 						lastCut = i;
 						polyline_number = polyline_number + 1;
 
-						//var p = new google.maps.LatLng(mapData[i-1][0], mapData[i-1][1]);
-						//points.push(p);
-						//bounds.extend(p);
+						// var p = new google.maps.LatLng(mapData[i-1][0], mapData[i-1][1]);
+						// points.push(p);
+						// bounds.extend(p);
+
 					} else {
 						var p = new google.maps.LatLng( mapData[i][0], mapData[i][1]);
 						points.push( p );
@@ -208,7 +209,6 @@ var WPGPXMAPS = {
 						strokeWeight: 4,
 						map: this.map
 					});
-
 					polylinenes.push( poly );
 					currentPoints = [];
 					polyline_number = polyline_number + 1;
@@ -219,7 +219,7 @@ var WPGPXMAPS = {
 					var startMarker = new google.maps.Marker({
 						position: points[0],
 						map: this.map,
-						title: "Start",
+						title: 'Start',
 						animation: google.maps.Animation.DROP,
 						icon: startIconImage,
 						zIndex: 10
@@ -232,7 +232,7 @@ var WPGPXMAPS = {
 					var startMarker = new google.maps.Marker({
 						position: points[ points.length -1 ],
 						map: this.map,
-						title: "Start",
+						title: 'End',
 						animation: google.maps.Animation.DROP,
 						icon: endIconImage,
 						zIndex: 10
@@ -240,10 +240,10 @@ var WPGPXMAPS = {
 
 				}
 
-				var first = WPGPXMAPS.Utils.GetItemFromArray( mapData, 0 )
+				var first = WPGPXMAPS.Utils.GetItemFromArray( mapData, 0 );
 
 				if ( currentIcon == '' ) {
-					currentIcon = "https://maps.google.com/mapfiles/kml/pal4/icon25.png";
+					currentIcon = 'https://maps.google.com/mapfiles/kml/pal4/icon25.png';
 				}
 
 				var current = new google.maps.MarkerImage( currentIcon,
@@ -254,14 +254,13 @@ var WPGPXMAPS = {
 
 				var marker = new google.maps.Marker({
 					position: new google.maps.LatLng( first[0], first[1]),
-					title: "Start",
+					title: 'Current',
 					icon: current,
 					map: this.map,
 					zIndex: 10
 				});
 
 				for ( i = 0; i < polylinenes.length; i++ ) {
-
 					google.maps.event.addListener( polylinenes[i], 'mouseover', function( event ) {
 						if ( marker ) {
 							marker.setPosition( event.latLng );
@@ -292,15 +291,11 @@ var WPGPXMAPS = {
 						}
 					});
 				}
-
-
 			},
 			this.AddWaypoints = function( waypoints, waypointIcon ) {
-
 			},
 			this.MoveMarkerToPosition = function( LatLon, updateChart ) {
-
-			}
+			};
 		},
 
 		Leaflet: function() {
@@ -319,14 +314,14 @@ var WPGPXMAPS = {
 					}
 				);
 
-				// create fullscreen control
+				/* create fullscreen control. */
 				var fsControl = new L.Control.FullScreen();
 
-				// add fullscreen control to the map
+				/* Add fullscreen control to the map. */
 				this.map.addControl( fsControl );
 
 				L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+					attribution: 'Data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 				}).addTo( this.map );
 
 				var hasThunderforestApiKey = ( ThunderforestApiKey + '' ).length > 0;
@@ -338,74 +333,85 @@ var WPGPXMAPS = {
 				var defaultMpaLayer = null;
 
 				if ( hasThunderforestApiKey ) {
-					baseMaps['Open Cycle Map'] = L.tileLayer( 'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
+
+					/* Map type: Thunderforst - OpenCycleMap with API key */
+					baseMaps['Thunderforest - Cycle'] = L.tileLayer( 'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
 						maxZoom: 18,
-						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+						attribution: 'Maps &copy; <a href="https://www.thunderforest.com/">Thunderforest</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
-					baseMaps['Open Cycle Map - Transport'] = L.tileLayer( 'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
+					/* Map type: Thunderforst - Transport with API key */
+					baseMaps['Thunderforst - Transport'] = L.tileLayer( 'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
 						maxZoom: 18,
-						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+						attribution: 'Maps &copy; <a href="https://www.thunderforest.com/">Thunderforest</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
-					baseMaps['Open Cycle Map - Landscape'] = L.tileLayer( 'https://a.tile.thunderforest.com/landscape/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
+					/* Map type: Thunderforst - Landscape with API key */
+					baseMaps['Thunderforst - Landscape'] = L.tileLayer( 'https://a.tile.thunderforest.com/landscape/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
 						maxZoom: 18,
-						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+						attribution: 'Maps &copy; <a href="https://www.thunderforest.com/">Thunderforest</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 						});
 
 				} else {
 
-					baseMaps['Open Cycle Map'] = L.tileLayer( 'http://a.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png', {
+					/* Map type: Open Cycle Map - Cycle */
+					baseMaps['Open Cycle Map - Cycle'] = L.tileLayer( 'http://a.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png', {
 						maxZoom: 18,
-						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+						attribution: 'Maps &copy; <a href="https://www.thunderforest.com/">Thunderforest</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
+					/* Map type: Open Cycle Map - Transport */
 					baseMaps['Open Cycle Map - Transport'] = L.tileLayer( 'https://a.tile2.opencyclemap.org/transport/{z}/{x}/{y}.png', {
 						maxZoom: 18,
-						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+						attribution: 'Maps &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
+					/* Map type: Open Cycle Map - Landscape */
 					baseMaps['Open Cycle Map - Landscape'] = L.tileLayer( 'https://a.tile3.opencyclemap.org/landscape/{z}/{x}/{y}.png', {
 						maxZoom: 18,
-						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+						attribution: 'Maps &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
 				}
 
+				/* Map type: Open Street Map */
 				baseMaps['Open Street Map'] = L.tileLayer( 'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 					maxZoom: 18,
-					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+					attribution: 'Maps &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
-
+				/* Map type: MapToolKit - Terrain */
 				baseMaps['MapToolKit - Terrain'] = L.tileLayer( 'https://tile2.maptoolkit.net/terrain/{z}/{x}/{y}.png', {
 					maxZoom: 18,
-					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+					attribution: 'Maps &copy; <a href="https://www.maptoolkit.net/">Maptoolkit</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
+				/* Map type: Open Street Map - Humanitarian Map Style */
 				baseMaps['Humanitarian Map Style'] = L.tileLayer( 'https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
 					maxZoom: 18,
-					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+					attribution: 'Maps &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
+
 				/*
+				Map type: Open Ski Map
 				baseMaps['Open Ski Map'] = L.tileLayer( 'http://tiles.skimap.org/openskimap/{z}/{x}/{y}.png', {
 					maxZoom: 18,
 					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
@@ -414,62 +420,85 @@ var WPGPXMAPS = {
 				});
 				*/
 
+				/* Map type: Hike & Bike */
 				baseMaps['Hike & Bike'] = L.tileLayer( 'http://toolserver.org/tiles/hikebike/{z}/{x}/{y}.png', {
 					maxZoom: 18,
-					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+					attribution: 'Maps &copy; <a href="https://hikebikemap.org/">Hike & Bike Map</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
+				/* Map type: Open Sea Map */
 				baseMaps['Open Sea Map'] = L.tileLayer( 'http://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
 					maxZoom: 18,
-					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+					attribution: 'Maps &copy; <a href="https://www.openseamap.org/">OpenSeaMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
-
 				switch ( mapType ) {
+
+					/* Map type: Open Street Map */
 					case 'OSM1': {
 						baseMaps['Open Street Map'].addTo( this.map );
 						break;
 					}
+
+					/* Map type: Thunderforst - Open Cycle Maps with API key or Open Cycle Map - Cycle */
 					case 'OSM2': {
-						baseMaps['Open Cycle Map'].addTo( this.map );
+						baseMaps['Open Cycle Map - Cycle'].addTo( this.map );
 						break;
 					}
+
+					/* Map type: Thunderforst - Landscape with API key or Open Cycle Map - Landscape */
 					case 'OSM4': {
 						baseMaps['Open Cycle Map - Transport'].addTo( this.map );
 						break;
 					}
+
+					/* Map type: Thunderforst - Landscape with API key or Open Cycle Map - Landscape */
 					case 'OSM5': {
 						baseMaps['Open Cycle Map - Landscape'].addTo( this.map );
 						break;
 					}
+
+					/* Map type: MapToolKit - Terrain */
 					case 'OSM6': {
 						baseMaps['MapToolKit - Terrain'].addTo( this.map );
 						break;
 					}
+
+					/* Map type: Open Street Map - Humanitarian Map Style*/
 					case 'OSM7': {
 						baseMaps['Humanitarian Map Style'].addTo( this.map );
 						break;
 					}
+
+					/*
+					Map type: Open Ski Map
 					case 'OSM8': {
 						baseMaps['Open Ski Map'].addTo( this.map );
 						break;
 					}
+					*/
+
+					/* Map type: Hike & Bike */
 					case 'OSM9': {
 						baseMaps['Hike & Bike'].addTo( this.map );
 						break;
 					}
+
+					/* Map type: Open Sea Map */
 					case 'OSM10': {
 						baseMaps['Open Sea Map'].addTo( this.map );
 						break;
 					}
 
+					/* Map type: Open Street Map */
 					default: {
 						baseMaps['Open Street Map'].addTo( this.map );
 					}
+
 				}
 
 				L.control.layers( baseMaps, overlayMaps ).addTo( this.map );
@@ -481,17 +510,17 @@ var WPGPXMAPS = {
 				var first = WPGPXMAPS.Utils.GetItemFromArray( mapData, 0 );
 
 				if ( currentIcon == '' ) {
-					currentIcon = "https://maps.google.com/mapfiles/kml/pal4/icon25.png";
+					currentIcon = 'https://maps.google.com/mapfiles/kml/pal4/icon25.png';
 				}
 
 				var CurrentPositionMarker = L.marker( first, { icon: L.icon ({
 					iconUrl: currentIcon,
-					iconSize: [ 32, 32 ], // size of the icon
-					iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
+					iconSize: [ 32, 32 ], // Size of the icon.
+					iconAnchor: [ 16, 16 ] // Point of the icon which will correspond to marker's location.
 				})
 				});
 				CurrentPositionMarker.addTo( this.map );
-				CurrentPositionMarker.title = 'Start';
+				CurrentPositionMarker.title = 'Current';
 
 				this.CurrentPositionMarker = CurrentPositionMarker;
 
@@ -505,7 +534,6 @@ var WPGPXMAPS = {
 				this.CenterMap();
 
 				for ( i = 0; i < pointsArray.length; i++ ) {
-
 					if ( i < color1.length ) {
 						color = color1[i];
 					} else {
@@ -522,21 +550,19 @@ var WPGPXMAPS = {
 						});
 					} catch ( err ) {
 					}
-
 				}
 
 				if ( startIcon != '' ) {
 
 					var startMarker = L.marker( mapData[0], {icon: L.icon({
 						iconUrl: startIcon,
-						iconSize: [ 32, 32 ], // size of the icon
-						iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
+						iconSize: [ 32, 32 ], // Size of the icon.
+						iconAnchor: [ 16, 16 ] // Point of the icon which will correspond to marker's location.
 					})
 					});
+
 					startMarker.addTo( this.map );
 					startMarker.title = 'Start';
-
-
 				}
 
 				if ( endIcon != '' ) {
@@ -547,13 +573,12 @@ var WPGPXMAPS = {
 						iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
 					})
 					});
+
 					endMarker.addTo( this.map );
 					endMarker.title = 'End';
-
 				}
 
-
-	/*
+				/*
 				var current = new google.maps.MarkerImage(currentIcon,
 					new google.maps.Size(32, 32),
 					new google.maps.Point(0,0),
@@ -606,8 +631,7 @@ var WPGPXMAPS = {
 						}
 					});
 				}
-
-		*/
+				*/
 
 			},
 
@@ -615,15 +639,15 @@ var WPGPXMAPS = {
 
 				var icon = L.icon({
 					iconUrl: 'https://maps.google.com/mapfiles/ms/micons/flag.png',
-					iconSize: [ 32, 32 ], // size of the icon
-					iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
+					iconSize: [ 32, 32 ], // Size of the icon.
+					iconAnchor: [ 16, 16 ] // Point of the icon which will correspond to marker's location.
 				});
 
 				if ( waypointIcon != '' ) {
 					icon = L.icon({
 						iconUrl: 'waypointIcon',
-						iconSize: [ 32, 32 ], // size of the icon
-						iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
+						iconSize: [ 32, 32 ], // Size of the icon.
+						iconAnchor: [ 16, 16 ] // Point of the icon which will correspond to marker's location.
 					});
 				}
 
@@ -641,9 +665,7 @@ var WPGPXMAPS = {
 						icon.iconUrl = wpt.img;
 						wsh = '';
 					}
-
 					var marker = L.marker([ lat, lon ], {icon: icon });
-
 					var cnt = '';
 
 					if ( wpt.name == '' ) {
@@ -651,15 +673,10 @@ var WPGPXMAPS = {
 					} else {
 						cnt = "<div><b>" + wpt.name + "</b><br />" + unescape( wpt.desc ) + "</div>";
 					}
-
 					cnt += "<br /><p><a href='https://maps.google.com?daddr=" + lat + "," + lon + "' target='_blank'>Itin&eacute;raire</a></p>";
-
 					marker.addTo( this.map ).bindPopup( cnt );
-
 				}
-
 				this.CenterMap();
-
 			},
 
 			this.MoveMarkerToPosition = function( LatLon, updateChart ) {
@@ -678,11 +695,8 @@ var WPGPXMAPS = {
 			this.CenterMap = function() {
 				this.map.fitBounds( this.Bounds );
 			};
-
 		}
-
 	}
-
 };
 
 (function( $ ) {
@@ -728,13 +742,13 @@ var WPGPXMAPS = {
 
 		var _formats = [];
 
-		// Unit of measure settings
+		/* Unit of measure settings. */
 		var l_s;
 		var l_x;
 		var l_y;
-		var l_grade = { suf: "%", dec: 1 };
-		var l_hr = { suf: "", dec: 0 };
-		var l_cad = { suf: "", dec: 0 };
+		var l_grade = { suf: '%', dec: 1 };
+		var l_hr = { suf: '', dec: 0 };
+		var l_cad = { suf: '', dec: 0 };
 
 		var el = document.getElementById( 'wpgpxmaps_' + targetId );
 		var el_map = document.getElementById( 'map_' + targetId );
@@ -746,10 +760,12 @@ var WPGPXMAPS = {
 
 		var map = new WPGPXMAPS.MapEngines.Leaflet();
 		map.lng = lng;
-		map.init( 'map_' + targetId,
-						mapType,
-						( zoomOnScrollWheel == 'true' ),
-						ThunderforestApiKey );
+		map.init(
+			'map_' + targetId,
+			mapType,
+			( 'true' == zoomOnScrollWheel ),
+			ThunderforestApiKey
+		);
 
 		map.EventSelectChart = function( LatLon ) {
 
@@ -774,36 +790,31 @@ var WPGPXMAPS = {
 					myChart.tooltip.update( true );
 					myChart.draw();
 				}
-
 			}
-		}
+		};
 
-		//var bounds = new google.maps.LatLngBounds();
+		// var bounds = new google.maps.LatLngBounds();
 
+		if ( 'true' == usegpsposition ) {
 
-		if ( usegpsposition == 'true'  ) {
-
-			// Try HTML5 geolocation
+			/* Try HTML5 geolocation. */
 			if ( navigator.geolocation ) {
-
 				var context = map;
-
 				navigator.geolocation.watchPosition( function( position ) {
-
 					var radius = position.coords.accuracy / 2;
 
-					// user position
+					/* User position. */
 					var pos = [ position.coords.latitude, position.coords.longitude ];
 
 					if ( context.CurrentGPSPositionMarker == null ) {
 						if ( currentpositioncon == '' ) {
-							currentpositioncon = "https://maps.google.com/mapfiles/kml/pal4/icon25.png";
+							currentpositioncon = 'https://maps.google.com/mapfiles/kml/pal4/icon25.png';
 						}
 
 						context.CurrentGPSPositionMarker = L.marker( pos, {icon: L.icon({
 							iconUrl: currentpositioncon,
-							iconSize: [ 32, 32 ], // size of the icon
-							iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
+							iconSize: [ 32, 32 ], // Size of the icon.
+							iconAnchor: [ 16, 16 ] // Point of the icon which will correspond to marker's location.
 						})
 						})
 						.addTo( context.map )
@@ -813,15 +824,13 @@ var WPGPXMAPS = {
 					} else {
 						context.CurrentGPSPositionMarker.setLatLng( pos );
 					}
-
 					context.Bounds.push( pos );
-
 					context.CenterMap();
-
 				},
 				function( e ) {
 
-					// some errors
+					// Some errors.
+
 				},
 				{
 				enableHighAccuracy: false,
@@ -829,17 +838,14 @@ var WPGPXMAPS = {
 				maximumAge: 0
 				});
 			}
-
 		}
 
-
-		// Print WayPoints
+		/* Print WayPoints. */
 		if ( ! jQuery.isEmptyObject( waypoints ) && waypoints.length > 0 ) {
 			map.AddWaypoints( waypoints, waypointIcon );
 		}
 
-		// Print Images
-
+		/* Print Images. */
 		jQuery( "#ngimages_" + targetId ).attr( "style", "display:block;position:absolute;left:-50000px" );
 
 		var nggImages = jQuery( "#ngimages_" + targetId + " span" ).toArray();
@@ -853,18 +859,18 @@ var WPGPXMAPS = {
 				var ngg_span_a = ngg_span.children[0];
 
 				var pos = [
-					Number( ngg_span.getAttribute( "lat" ) ),
-					Number( ngg_span.getAttribute( "lon" ) )
+					Number( ngg_span.getAttribute( 'lat' ) ),
+					Number( ngg_span.getAttribute( 'lon' ) )
 				];
 
 				map.Bounds.push( pos );
 
 				photos.push({
-					"lat": pos[0],
-					"lng": pos[1],
-					"name": ngg_span_a.getAttribute( "data-title" ),
-					"url": ngg_span_a.getAttribute( "data-src" ),
-					"thumbnail": ngg_span_a.getAttribute( "data-thumbnail" )
+					'lat': pos[0],
+					'lng': pos[1],
+					'name': ngg_span_a.getAttribute( 'data-title' ),
+					'url': ngg_span_a.getAttribute( 'data-src' ),
+					'thumbnail': ngg_span_a.getAttribute( 'data-thumbnail' )
 				});
 
 			}
@@ -881,7 +887,6 @@ var WPGPXMAPS = {
 				photoLayer.add( photos ).addTo( map.map );
 
 				map.CenterMap();
-
 
 				/*
 				var showHideImagesCustomControl = L.Control.extend({
@@ -976,8 +981,7 @@ var WPGPXMAPS = {
 		}
 		*/
 
-
-		// Print Track
+		/* Print Track. */
 		if ( mapData != '' ) {
 			map.AppPolylines( mapData, color1, currentIcon, startIcon, endIcon );
 		}
@@ -987,19 +991,20 @@ var WPGPXMAPS = {
 		map.fitBounds(bounds);
 		*/
 
-		// FIX post tabs
+		// Fix post tabs. */
 		var $_tab = $( el ).closest( ".wordpress-post-tabs, .tab-pane" ).eq( 0 );
 		if ( $_tab ) {
 			var contextMap = map;
 
 			var FixMapSize = function( e ) {
 				setTimeout( function( e ) {
-					//google.maps.event.trigger(map, 'resize');
+
+					// google.maps.event.trigger(map, 'resize');
 					contextMap.map.invalidateSize();
 					contextMap.CenterMap();
 					tabResized = true;
 				}, 300 );
-			}
+			};
 
 			$( ".wpsm_nav-tabs a" ).click( FixMapSize );
 
@@ -1009,29 +1014,47 @@ var WPGPXMAPS = {
 
 		var graphh = jQuery( '#myChart_' + params.targetId ).css( "height" );
 
-		if ( graphDist != '' && ( graphEle != '' || graphSpeed != '' || graphHr != '' || graphAtemp != '' || graphCad != '' ) && graphh != "0px" ) {
+		if ( graphDist != '' && ( graphEle != '' || graphSpeed != '' || graphHr != '' || graphAtemp != '' || graphCad != '' ) && graphh != '0px' ) {
 
 			var valLen = graphDist.length;
 
 
-			if ( unit == "1" ) {
-				l_x = { suf: "mi", dec: 1 };
-				l_y = { suf: "ft", dec: 0 };
-			} else if ( unit == "2" ) {
-				l_x = { suf: "km", dec: 1 };
-				l_y = { suf: "m", dec: 0 };
-			} else if ( unit == "3" ) {
-				l_x = { suf: "NM", dec: 1 };
-				l_y = { suf: "m", dec: 0 };
-			} else if ( unit == "4" ) {
-				l_x = { suf: "mi", dec: 1 };
-				l_y = { suf: "m", dec: 0 };
-			} else if ( unit == "5" ) {
-				l_x = { suf: "NM", dec: 1 };
-				l_y = { suf: "ft", dec: 0 };
+			if ( '1' == unit ) {
+
+				/* feet / miles */
+				l_x = { suf: 'mi', dec: 1 };
+				l_y = { suf: 'ft', dec: 0 };
+
+			} else if ( '2' == unit ) {
+
+				/* meters / kilometers */
+				l_x = { suf: 'km', dec: 1 };
+				l_y = { suf: 'm', dec: 0 };
+
+			} else if ( '3' == unit ) {
+
+				/* meters / nautical miles */
+				l_x = { suf: 'NM', dec: 1 };
+				l_y = { suf: 'm', dec: 0 };
+
+			} else if ( '4' == unit ) {
+
+				/* meters / miles */
+				l_x = { suf: 'mi', dec: 1 };
+				l_y = { suf: 'm', dec: 0 };
+
+			} else if ( '5' == unit ) {
+
+				/* feet / nautical miles */
+				l_x = { suf: 'NM', dec: 1 };
+				l_y = { suf: 'ft', dec: 0 };
+
 			} else {
-				l_x = { suf: "m", dec: 0 };
-				l_y = { suf: "m", dec: 0 };
+
+				/* meters / meters */
+				l_x = { suf: 'm', dec: 0 };
+				l_y = { suf: 'm', dec: 0 };
+
 			}
 
 			var nn = 1111.1;
@@ -1040,13 +1063,13 @@ var WPGPXMAPS = {
 			var decPoint = _nn.substring( _nnLen - 2, _nnLen - 1 );
 			var thousandsSep = _nn.substring( 1, 2 );
 
-			if ( decPoint == "1" )
-				decPoint = ".";
+			if ( '1' == decPoint )
+				decPoint = '.';
 
-			if ( thousandsSep == "1" )
-				thousandsSep = "";
+			if ( '1' == thousandsSep )
+				thousandsSep = '';
 
-			// define the options
+			/* Define the options. */
 			var hoptions = {
 				type: 'line',
 				data: {
@@ -1055,12 +1078,18 @@ var WPGPXMAPS = {
 				borderWidth: 1,
 				options: {
 					animation: {
-						//duration: 0, // general animation time
+
+						// duration: 0,
+						// general animation time
 					},
 					hover: {
-						//animationDuration: 0, // duration of animations when hovering an item
+
+						// animationDuration: 0,
+						// duration of animations when hovering an item
 					},
-					//responsiveAnimationDuration: 0, // animation duration after a resize
+
+					// responsiveAnimationDuration: 0,
+					// animation duration after a resize
 					customLine: {
 						color: 'gray'
 					},
@@ -1071,7 +1100,8 @@ var WPGPXMAPS = {
 							ticks: {
 								suggestedMin: 0,
 								max: graphDist[graphDist.length - 1],
-								// Include a dollar sign in the ticks
+
+								/* Include a dollar sign in the ticks. */
 								callback: function( value, index, values ) {
 									return Math.round( value, l_x.dec ) + l_x.suf;
 								}
@@ -1084,12 +1114,14 @@ var WPGPXMAPS = {
 						intersect: false,
 						callbacks: {
 							title: function( tooltipItems, data ) {
-								//Return value for title
+
+								/* Return value for title: */
 								var fpt = _formats[0];
 								return Math.round( tooltipItems[0].xLabel, fpt.dec ) + fpt.suf;;
 							},
 							label: function( tooltipItem, data ) {
-								// format list values
+
+								/* Format list values: */
 								var label = data.datasets[tooltipItem.datasetIndex].label || '';
 								var fpt = _formats[tooltipItem.datasetIndex];
 								if ( label ) {
@@ -1099,11 +1131,11 @@ var WPGPXMAPS = {
 								return label;
 							},
 							footer: function( tooltipItem ) {
-								// move the point in map
-								var i = tooltipItem[0].index;
-								var point = WPGPXMAPS.Utils.GetItemFromArray( mapData, i )
-								map.MoveMarkerToPosition( point, false );
 
+								/* Move the point in map. */
+								var i = tooltipItem[0].index;
+								var point = WPGPXMAPS.Utils.GetItemFromArray( mapData, i );
+								map.MoveMarkerToPosition( point, false );
 							}
 						}
 					}
@@ -1136,80 +1168,114 @@ var WPGPXMAPS = {
 			};
 
 			if ( graphEle != '' ) {
-
 				var myData = mergeArrayForChart( graphDist, graphEle );
-
 				var yaxe = {
 					type: 'linear',
 					ticks: {
-						// Include a dollar sign in the ticks
+
+						/* Include a dollar sign in the ticks. */
 						callback: function( value, index, values ) {
 							return Math.round( value, l_y.dec ) + l_y.suf;
 						}
 					},
-					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
+					id: 'y-axis-' + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
 				if ( chartFrom1 != '' )	{
+
 					yaxe.min = chartFrom1;
 					yaxe.startOnTick = false;
+
 				} else {
+
 					yaxe.min = myData.Min;
+
 				}
+
 				if ( chartTo1 != '' ) {
+
 					yaxe.max = chartTo1;
 					yaxe.endOnTick = false;
+
 				} else {
+
 					yaxe.max = myData.Max;
 				}
-				_formats.push( l_y )
+
+				_formats.push( l_y );
 				hoptions.options.scales.yAxes.push( yaxe );
 				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.altitude, myData.Items, color2, yaxe.id ) );
 
 			}
 
 			if ( graphSpeed != '' ) {
-				if ( unitspeed == '6' ) /* min/100m */ {
-					l_s = { suf: "min/100m", dec: 2 };
-				} else if ( unitspeed == '5' ) /* knots */ {
-					l_s = { suf: "knots", dec: 2 };
-				} else if ( unitspeed == '4' ) /* min/miles */ {
-					l_s = { suf: "min/mi", dec: 2 };
-				} else if ( unitspeed == '3' ) /* min/km */ {
-					l_s = { suf: "min/km", dec: 2 };
-				} else if ( unitspeed == '2' ) /* miles/h */ {
-					l_s = { suf: "mi/h", dec: 0 };
-				} else if ( unitspeed == '1' ) /* km/h */ {
-					l_s = { suf: "km/h", dec: 0 };
+
+				if ( '6' == unitspeed ) {
+
+					/* min/100 meters */
+					l_s = { suf: 'min/100m', dec: 2 };
+
+				} else if ( '5' == unitspeed ) {
+
+					/* knots */
+					l_s = { suf: 'knots', dec: 2 };
+
+				} else if ( '4' == unitspeed ) {
+
+					/* min/miles */
+					l_s = { suf: 'min/mi', dec: 2 };
+
+				} else if ( '3' == unitspeed ) {
+
+					/* min/km */
+					l_s = { suf: 'min/km', dec: 2 };
+
+				} else if ( '2' == unitspeed ) {
+
+					/* miles/h */
+					l_s = { suf: 'mi/h', dec: 0 };
+
+				} else if ( '1' == unitspeed ) {
+
+					/* km/h */
+					l_s = { suf: 'km/h', dec: 0 };
+
 				} else {
-					l_s = { suf: "m/s", dec: 0 };
+
+					/* dafault m/s */
+					l_s = { suf: 'm/s', dec: 0 };
+
 				}
 
 				var myData = mergeArrayForChart( graphDist, graphSpeed );
-
 				var yaxe = {
 					type: 'linear',
 					ticks: {
-						// Include a dollar sign in the ticks
+
+						/* Include a dollar sign in the ticks. */
 						callback: function( value, index, values ) {
 							return Math.round( value, l_s.dec ) + l_s.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
+					id: 'y-axis-' + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
 				if ( chartFrom2 != '' ) {
+
 					yaxe.min = chartFrom2;
 					yaxe.startOnTick = false;
+
 				} else {
 					yaxe.min = myData.Min;
 				}
 
 				if ( chartTo2 != '' ) {
+
 					yaxe.max = chartTo2;
 					yaxe.endOnTick = false;
+
 				} else {
 					yaxe.max = myData.Max;
 				}
@@ -1217,71 +1283,64 @@ var WPGPXMAPS = {
 				_formats.push ( l_s );
 				hoptions.options.scales.yAxes.push( yaxe );
 				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.speed, myData.Items, color3, yaxe.id ) );
-
 			}
 
 			if ( graphHr != '' ) {
-
 				var myData = mergeArrayForChart( graphDist, graphHr );
-
 				var yaxe = {
 					type: 'linear',
 					ticks: {
-						// Include a dollar sign in the ticks
+
+						/* Include a dollar sign in the ticks. */
 						callback: function( value, index, values ) {
 							return Math.round( value, l_hr.dec ) + l_hr.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
+					id: 'y-axis-' + ( hoptions.options.scales.yAxes.length + 1 )
 				};
-
 				hoptions.options.scales.yAxes.push( yaxe );
 				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.heartRate, myData.Items, color4, yaxe.id ) );
 				_formats.push( l_hr );
 			}
 
-
 			if ( graphAtemp != '' ) {
-
 				var myData = mergeArrayForChart( graphDist, graphAtemp );
-
 				var yaxe = {
 					type: 'linear',
 					ticks: {
-						// Include a dollar sign in the ticks
+
+						/* Include a dollar sign in the ticks. */
 						callback: function( value, index, values ) {
 							return Math.round( value, 1 ) + "°C";
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
+					id: 'y-axis-' + ( hoptions.options.scales.yAxes.length + 1 )
 				};
-
 				hoptions.options.scales.yAxes.push( yaxe );
 				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.atemp, myData.Items, color7, yaxe.id ) );
-				_formats.push({ suf: "°C", dec: 1 });
-
+				_formats.push({ suf: '°C', dec: 1 });
 			}
 
 
 			if ( graphCad != '' ) {
 
 				var myData = mergeArrayForChart( graphDist, graphCad, true );
-
 				var yaxe = {
 					type: 'linear',
 					ticks: {
-						// Include a dollar sign in the ticks
+
+						// Include a dollar sign in the ticks.
 						callback: function( value, index, values ) {
 							return Math.round( value, l_cad.dec ) + l_cad.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
+					id: 'y-axis-' + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
 				hoptions.options.scales.yAxes.push( yaxe );
@@ -1293,11 +1352,11 @@ var WPGPXMAPS = {
 			if ( graphGrade != '' ) {
 
 				var myData = mergeArrayForChart( graphDist, graphGrade );
-
 				var yaxe = {
 					type: 'linear',
 					ticks: {
-						// Include a dollar sign in the ticks
+
+						// Include a dollar sign in the ticks.
 						callback: function( value, index, values ) {
 							return Math.round( value, l_grade.dec ) + l_grade.suf;
 						}
@@ -1310,14 +1369,13 @@ var WPGPXMAPS = {
 				_formats.push( l_grade );
 				hoptions.options.scales.yAxes.push( yaxe );
 				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.grade, myData.Items, color6, yaxe.id ) );
-
 			}
 
-			var ctx = document.getElementById( "myChart_" + params.targetId ).getContext( '2d' );
+			var ctx = document.getElementById( 'myChart_' + params.targetId ).getContext( '2d' );
 			var myChart = new Chart( ctx, hoptions );
 
 		} else  {
-			jQuery( "#myChart_" + params.targetId ).css( "display", "none" );
+			jQuery( '#myChart_' + params.targetId ).css( "display", "none" );
 		}
 
         return this;
@@ -1352,7 +1410,7 @@ var WPGPXMAPS = {
 			Items: items,
 			Min: min,
 			Max: max
-		}
+		};
 	}
 
 	function wpgpxmapsGetDataset( name, data, color, id ) {
@@ -1365,7 +1423,7 @@ var WPGPXMAPS = {
 			borderWidth: 1,
 			pointHoverRadius: 1,
 			yAxisID: id
-		}
+		};
 	}
 
 	function hexToRgbA( hex, a ) {
@@ -1376,7 +1434,7 @@ var WPGPXMAPS = {
 				c = [ c[0], c[0], c[1], c[1], c[2], c[2] ];
 			}
 			c = '0x' + c.join( '' );
-			return 'rgba(' + [ ( c>>16 )&255, ( c>>8)&255, c&255 ].join( ',' ) + ',' + a + ' )';
+			return 'rgba(' + [ ( c>>16 )&255, ( c>>8 )&255, c&255 ].join( ',' ) + ',' + a + ' )';
 		}
 		throw new Error( 'Bad Hex' );
 	}
@@ -1413,8 +1471,8 @@ var WPGPXMAPS = {
 		var divImages = document.getElementById( "ngimages_" + targetId );
 		var img_spans = divImages.getElementsByTagName( "span" );
 		for ( var i = 0; i < img_spans.length; i++ ) {
-			var imageLat = img_spans[i].getAttribute( "lat" );
-			var imageLon = img_spans[i].getAttribute( "lon" );
+			var imageLat = img_spans[i].getAttribute( 'lat' );
+			var imageLon = img_spans[i].getAttribute( 'lon' );
 
 			imageLat = imageLat.replace( ",", "." );
 			imageLon = imageLon.replace( ",", "." );
@@ -1434,7 +1492,8 @@ var WPGPXMAPS = {
 	}
 
 	function wpgpxmapsDist( lat1, lon1, lat2, lon2 ) {
-		// mathematically not correct but fast
+
+		// Mathematically not correct but fast.
 		var dLat = ( lat2 - lat1 );
 		var dLon = ( lon2 - lon1 );
 		return Math.sqrt( dLat * dLat + dLon * dLon );

--- a/js/WP-GPX-Maps.js
+++ b/js/WP-GPX-Maps.js
@@ -41,7 +41,7 @@ var WPGPXMAPS = {
 			} catch ( e ) {
 				return [ 0, 0 ];
 			}
-		},
+		}
 
 
 	},
@@ -57,7 +57,7 @@ var WPGPXMAPS = {
 
 				var mapTypeIds = [];
 				for ( var type in google.maps.MapTypeId ) {
-					mapTypeIds.push( google.maps.MapTypeId[type] );
+					mapTypeIds.push( google.maps.MapTypeId[type]);
 				}
 				mapTypeIds.push( 'OSM1' );
 				mapTypeIds.push( 'OSM2' );
@@ -123,7 +123,7 @@ var WPGPXMAPS = {
 					name: 'OCM',
 					alt: 'Open Cycle Map',
 					maxZoom: 18
-				}));
+				}) );
 
 				this.map.mapTypes.set( 'OSM4', new google.maps.ImageMapType({
 					getTileUrl: function( coord, zoom ) {
@@ -133,7 +133,7 @@ var WPGPXMAPS = {
 							return "http://a.tile2.opencyclemap.org/transport/" + zoom + "/" + coord.x + "/" + coord.y + '.png';
 						}
 					},
-					tileSize: new google.maps.Size(256, 256),
+					tileSize: new google.maps.Size( 256, 256 ),
 					name: 'OCM-Tran',
 					alt: 'Open Cycle Map - Transport',
 					maxZoom: 18
@@ -172,10 +172,10 @@ var WPGPXMAPS = {
 				var polyline_number = 0;
 				var color = 0;
 				for ( i = 0; i < mapData.length; i++ ) {
-					if (mapData[i] == null) {
+					if ( mapData[i] == null ) {
 
 						var poly = new google.maps.Polyline({
-							path: points.slice(lastCut,i),
+							path: points.slice( lastCut, i ),
 							strokeColor: color,
 							strokeOpacity: .7,
 							strokeWeight: 4,
@@ -183,7 +183,7 @@ var WPGPXMAPS = {
 						});
 						polylinenes.push( poly );
 						lastCut = i;
-						polyline_number = polyline_number +1;
+						polyline_number = polyline_number + 1;
 
 						//var p = new google.maps.LatLng(mapData[i-1][0], mapData[i-1][1]);
 						//points.push(p);
@@ -217,26 +217,26 @@ var WPGPXMAPS = {
 				if ( startIcon != '' ) {
 					var startIconImage = new google.maps.MarkerImage( startIcon );
 					var startMarker = new google.maps.Marker({
-							  position: points[0],
-							  map: this.map,
-							  title: "Start",
-							  animation: google.maps.Animation.DROP,
-							  icon: startIconImage,
-							  zIndex: 10
-						  });
+						position: points[0],
+						map: this.map,
+						title: "Start",
+						animation: google.maps.Animation.DROP,
+						icon: startIconImage,
+						zIndex: 10
+					});
 
 				}
 
 				if ( endIcon != '' ) {
 					var endIconImage = new google.maps.MarkerImage( endIcon );
 					var startMarker = new google.maps.Marker({
-							  position: points[ points.length -1 ],
-							  map: this.map,
-							  title: "Start",
-							  animation: google.maps.Animation.DROP,
-							  icon: endIconImage,
-							  zIndex: 10
-						  });
+						position: points[ points.length -1 ],
+						map: this.map,
+						title: "Start",
+						animation: google.maps.Animation.DROP,
+						icon: endIconImage,
+						zIndex: 10
+					});
 
 				}
 
@@ -246,15 +246,15 @@ var WPGPXMAPS = {
 					currentIcon = "https://maps.google.com/mapfiles/kml/pal4/icon25.png";
 				}
 
-				var current = new google.maps.MarkerImage(currentIcon,
+				var current = new google.maps.MarkerImage( currentIcon,
 					new google.maps.Size( 32, 32 ),
-					new google.maps.Point( 0 ,0 ),
+					new google.maps.Point( 0, 0 ),
 					new google.maps.Point( 16, 16 )
 				);
 
 				var marker = new google.maps.Marker({
-					position: new google.maps.LatLng( first[0], first[1] ),
-					title:"Start",
+					position: new google.maps.LatLng( first[0], first[1]),
+					title: "Start",
 					icon: current,
 					map: this.map,
 					zIndex: 10
@@ -269,13 +269,13 @@ var WPGPXMAPS = {
 							if ( myChart ) {
 								var l1 = event.latLng.lat();
 								var l2 = event.latLng.lng();
-								var ci = getClosestIndex(mapData,l1,l2);
+								var ci = getClosestIndex( mapData, l1, l2 );
 								var activeElements = [];
 								var seriesLen = myChart.data.datasets.length;
-								for ( var i = 0; i<seriesLen;i++ ) {
-									activeElements.push( myChart.chart.getDatasetMeta( i ).data[ci] );
+								for ( var i = 0; i < seriesLen;i++ ) {
+									activeElements.push( myChart.chart.getDatasetMeta( i ).data[ci]);
 								}
-								if ( activeElements.length > 0) {
+								if ( activeElements.length > 0 ) {
 									myChart.options.customLine.x = activeElements[0]._model.x;
 									if ( isNaN( myChart.tooltip._eventPosition ) ) {
 										myChart.tooltip._eventPosition = {
@@ -315,7 +315,7 @@ var WPGPXMAPS = {
 
 				this.map = L.map( targetElement,
 					{
-						scrollWheelZoom : scrollWheelZoom,
+						scrollWheelZoom: scrollWheelZoom
 					}
 				);
 
@@ -325,7 +325,7 @@ var WPGPXMAPS = {
 				// add fullscreen control to the map
 				this.map.addControl( fsControl );
 
-				L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+				L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 				}).addTo( this.map );
 
@@ -342,21 +342,21 @@ var WPGPXMAPS = {
 						maxZoom: 18,
 						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
 					baseMaps['Open Cycle Map - Transport'] = L.tileLayer( 'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
 						maxZoom: 18,
 						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
 					baseMaps['Open Cycle Map - Landscape'] = L.tileLayer( 'https://a.tile.thunderforest.com/landscape/{z}/{x}/{y}.png?apikey=' + ThunderforestApiKey, {
 						maxZoom: 18,
 						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 						});
 
 				} else {
@@ -365,21 +365,21 @@ var WPGPXMAPS = {
 						maxZoom: 18,
 						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
 					baseMaps['Open Cycle Map - Transport'] = L.tileLayer( 'https://a.tile2.opencyclemap.org/transport/{z}/{x}/{y}.png', {
 						maxZoom: 18,
 						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
 					baseMaps['Open Cycle Map - Landscape'] = L.tileLayer( 'https://a.tile3.opencyclemap.org/landscape/{z}/{x}/{y}.png', {
 						maxZoom: 18,
 						attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 							'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+							'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 					});
 
 				}
@@ -388,7 +388,7 @@ var WPGPXMAPS = {
 					maxZoom: 18,
 					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
 
@@ -396,14 +396,14 @@ var WPGPXMAPS = {
 					maxZoom: 18,
 					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
 				baseMaps['Humanitarian Map Style'] = L.tileLayer( 'https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
 					maxZoom: 18,
 					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 				/*
 				baseMaps['Open Ski Map'] = L.tileLayer( 'http://tiles.skimap.org/openskimap/{z}/{x}/{y}.png', {
@@ -418,14 +418,14 @@ var WPGPXMAPS = {
 					maxZoom: 18,
 					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
 				baseMaps['Open Sea Map'] = L.tileLayer( 'http://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
 					maxZoom: 18,
 					attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 						'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+						'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>'
 				});
 
 
@@ -486,8 +486,8 @@ var WPGPXMAPS = {
 
 				var CurrentPositionMarker = L.marker( first, { icon: L.icon ({
 					iconUrl: currentIcon,
-					iconSize:     [32, 32], // size of the icon
-					iconAnchor:   [16, 16], // point of the icon which will correspond to marker's location
+					iconSize: [ 32, 32 ], // size of the icon
+					iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
 				})
 				});
 				CurrentPositionMarker.addTo( this.map );
@@ -512,13 +512,13 @@ var WPGPXMAPS = {
 						color = color1[color1.length - 1];
 					}
 					try {
-						var polyline = L.polyline( pointsArray[i], {color: color} ).addTo( this.map );
+						var polyline = L.polyline(  pointsArray[i], {color: color}).addTo( this.map );
 						this.Polylines.push( polyline );
 
 						var context = this;
 
-						this.Polylines[i].on('mousemove', function( e ) {
-							context.MoveMarkerToPosition( [e.latlng.lat, e.latlng.lng], true );
+						this.Polylines[i].on( 'mousemove', function( e ) {
+							context.MoveMarkerToPosition([ e.latlng.lat, e.latlng.lng ], true );
 						});
 					} catch ( err ) {
 					}
@@ -527,10 +527,10 @@ var WPGPXMAPS = {
 
 				if ( startIcon != '' ) {
 
-					var startMarker = L.marker( mapData[0], {icon: L.icon( {
+					var startMarker = L.marker( mapData[0], {icon: L.icon({
 						iconUrl: startIcon,
-						iconSize:     [32, 32], // size of the icon
-						iconAnchor:   [16, 16], // point of the icon which will correspond to marker's location
+						iconSize: [ 32, 32 ], // size of the icon
+						iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
 					})
 					});
 					startMarker.addTo( this.map );
@@ -541,10 +541,10 @@ var WPGPXMAPS = {
 
 				if ( endIcon != '' ) {
 
-					var endMarker = L.marker( mapData[ mapData.length - 1 ], {icon: L.icon( {
+					var endMarker = L.marker( mapData[ mapData.length - 1 ], {icon: L.icon({
 						iconUrl: endIcon,
-						iconSize:     [32, 32], // size of the icon
-						iconAnchor:   [16, 16], // point of the icon which will correspond to marker's location
+						iconSize: [ 32, 32 ], // size of the icon
+						iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
 					})
 					});
 					endMarker.addTo( this.map );
@@ -615,38 +615,38 @@ var WPGPXMAPS = {
 
 				var icon = L.icon({
 					iconUrl: 'https://maps.google.com/mapfiles/ms/micons/flag.png',
-					iconSize:     [32, 32], // size of the icon
-					iconAnchor:   [16, 16], // point of the icon which will correspond to marker's location
+					iconSize: [ 32, 32 ], // size of the icon
+					iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
 				});
 
-				if ( waypointIcon!='' ) {
+				if ( waypointIcon != '' ) {
 					icon = L.icon({
 						iconUrl: 'waypointIcon',
-						iconSize:     [32, 32], // size of the icon
-						iconAnchor:   [16, 16], // point of the icon which will correspond to marker's location
+						iconSize: [ 32, 32 ], // size of the icon
+						iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
 					});
 				}
 
 				for ( i = 0; i < waypoints.length; i++ ) {
 					var wpt = waypoints[i];
 
-					this.Bounds.push( [wpt.lat,wpt.lon] );
+					this.Bounds.push([ wpt.lat, wpt.lon ]);
 
-					var lat= wpt.lat;
-					var lon= wpt.lon;
-					var sym= wpt.sym;
-					var typ= wpt.type;
+					var lat = wpt.lat;
+					var lon = wpt.lon;
+					var sym = wpt.sym;
+					var typ = wpt.type;
 
 					if ( icon.img ) {
 						icon.iconUrl = wpt.img;
 						wsh = '';
 					}
 
-					var marker = L.marker( [lat, lon], {icon: icon } );
+					var marker = L.marker([ lat, lon ], {icon: icon });
 
 					var cnt = '';
 
-					if ( wpt.name=='' ) {
+					if ( wpt.name == '' ) {
 						cnt = "<div>" + unescape( wpt.desc ) + "</div>";
 					} else {
 						cnt = "<div><b>" + wpt.name + "</b><br />" + unescape( wpt.desc ) + "</div>";
@@ -732,15 +732,15 @@ var WPGPXMAPS = {
 		var l_s;
 		var l_x;
 		var l_y;
-		var l_grade = { suf : "%", dec : 1 };
-		var l_hr = { suf : "", dec : 0 };
-		var l_cad = { suf : "", dec : 0 };
+		var l_grade = { suf: "%", dec: 1 };
+		var l_hr = { suf: "", dec: 0 };
+		var l_cad = { suf: "", dec: 0 };
 
-		var el = document.getElementById('wpgpxmaps_' + targetId);
-		var el_map = document.getElementById('map_' + targetId);
-		var el_chart = document.getElementById('chart_' + targetId);
-		var el_report = document.getElementById('report_' + targetId);
-		var el_osm_credits = document.getElementById('wpgpxmaps_' + targetId + '_osm_footer');
+		var el = document.getElementById( 'wpgpxmaps_' + targetId );
+		var el_map = document.getElementById( 'map_' + targetId );
+		var el_chart = document.getElementById( 'chart_' + targetId );
+		var el_report = document.getElementById( 'report_' + targetId );
+		var el_osm_credits = document.getElementById( 'wpgpxmaps_' + targetId + '_osm_footer' );
 
 		var mapWidth = el_map.style.width;
 
@@ -749,7 +749,7 @@ var WPGPXMAPS = {
 		map.init( 'map_' + targetId,
 						mapType,
 						( zoomOnScrollWheel == 'true' ),
-						ThunderforestApiKey);
+						ThunderforestApiKey );
 
 		map.EventSelectChart = function( LatLon ) {
 
@@ -800,7 +800,7 @@ var WPGPXMAPS = {
 							currentpositioncon = "https://maps.google.com/mapfiles/kml/pal4/icon25.png";
 						}
 
-						context.CurrentGPSPositionMarker = L.marker(pos, {icon: L.icon({
+						context.CurrentGPSPositionMarker = L.marker( pos, {icon: L.icon({
 							iconUrl: currentpositioncon,
 							iconSize: [ 32, 32 ], // size of the icon
 							iconAnchor: [ 16, 16 ] // point of the icon which will correspond to marker's location
@@ -840,47 +840,45 @@ var WPGPXMAPS = {
 
 		// Print Images
 
-		jQuery("#ngimages_" + targetId).attr("style","display:block;position:absolute;left:-50000px");
+		jQuery( "#ngimages_" + targetId ).attr( "style", "display:block;position:absolute;left:-50000px" );
 
-		var nggImages = jQuery("#ngimages_" + targetId + " span").toArray();
+		var nggImages = jQuery( "#ngimages_" + targetId + " span" ).toArray();
 
-		if (nggImages !== undefined && nggImages.length > 0)
-		{
+		if ( nggImages !== undefined && nggImages.length > 0 ) {
 			var photos = [];
 
-			for (var i = 0; i < nggImages.length; i++) {
+			for ( var i = 0; i < nggImages.length; i++ ) {
 
 				var ngg_span = nggImages[i];
 				var ngg_span_a = ngg_span.children[0];
 
 				var pos = [
-							Number(ngg_span.getAttribute("lat")),
-							Number(ngg_span.getAttribute("lon"))
-							];
+					Number( ngg_span.getAttribute( "lat" ) ),
+					Number( ngg_span.getAttribute( "lon" ) )
+				];
 
-				map.Bounds.push(pos);
+				map.Bounds.push( pos );
 
 				photos.push({
-							  "lat": pos[0],
-							  "lng": pos[1],
-							  "name": ngg_span_a.getAttribute("data-title"),
-							  "url": ngg_span_a.getAttribute("data-src"),
-							  "thumbnail": ngg_span_a.getAttribute("data-thumbnail")
-							});
+					"lat": pos[0],
+					"lng": pos[1],
+					"name": ngg_span_a.getAttribute( "data-title" ),
+					"url": ngg_span_a.getAttribute( "data-src" ),
+					"thumbnail": ngg_span_a.getAttribute( "data-thumbnail" )
+				});
 
 			}
 
-			if (photos.length > 0)
-			{
-				var photoLayer = L.photo.cluster().on('click', function(evt) {
-					  var photo = evt.layer.photo;
-					  var template = '<img src="{url}" /></a><p>{name}</p>';
-					  evt.layer.bindPopup(L.Util.template(template, photo), {
-							minWidth: 'auto',
-					  }).openPopup();
-				});
+			if ( photos.length > 0 ) {
+				var photoLayer = L.photo.cluster().on( 'click', function( evt ) {
+					var photo = evt.layer.photo;
+					var template = '<img src="{url}" /></a><p>{name}</p>';
+					evt.layer.bindPopup( L.Util.template( template, photo ), {
+					minWidth: 'auto'
+				}).openPopup();
+			});
 
-				photoLayer.add(photos).addTo(map.map);
+				photoLayer.add( photos ).addTo( map.map );
 
 				map.CenterMap();
 
@@ -980,9 +978,8 @@ var WPGPXMAPS = {
 
 
 		// Print Track
-		if (mapData != '')
-		{
-			map.AppPolylines(mapData, color1, currentIcon, startIcon, endIcon);
+		if ( mapData != '' ) {
+			map.AppPolylines( mapData, color1, currentIcon, startIcon, endIcon );
 		}
 
 		/*
@@ -991,83 +988,69 @@ var WPGPXMAPS = {
 		*/
 
 		// FIX post tabs
-		var $_tab = $(el).closest(".wordpress-post-tabs, .tab-pane").eq(0);
-		if ($_tab)
-		{
+		var $_tab = $( el ).closest( ".wordpress-post-tabs, .tab-pane" ).eq( 0 );
+		if ( $_tab ) {
 			var contextMap = map;
 
-			var FixMapSize = function(e)
-			{
-				setTimeout(function(e){
+			var FixMapSize = function( e ) {
+				setTimeout( function( e ) {
 					//google.maps.event.trigger(map, 'resize');
 					contextMap.map.invalidateSize();
 					contextMap.CenterMap();
 					tabResized = true;
-				}, 300);
+				}, 300 );
 			}
 
-			$(".wpsm_nav-tabs a").click(FixMapSize);
+			$( ".wpsm_nav-tabs a" ).click( FixMapSize );
 
-			$("div > ul > li > a", $_tab).click(FixMapSize);
+			$( "div > ul > li > a", $_tab ).click( FixMapSize );
 		}
 
 
-		var graphh = jQuery('#myChart_' + params.targetId).css("height");
+		var graphh = jQuery( '#myChart_' + params.targetId ).css( "height" );
 
-		if (graphDist != '' && (graphEle != '' || graphSpeed != '' || graphHr != '' || graphAtemp != '' || graphCad != '') && graphh != "0px")
-		{
+		if ( graphDist != '' && ( graphEle != '' || graphSpeed != '' || graphHr != '' || graphAtemp != '' || graphCad != '' ) && graphh != "0px" ) {
 
 			var valLen = graphDist.length;
 
 
-			if (unit=="1")
-			{
-				l_x = { suf : "mi", dec : 1 };
-				l_y = { suf : "ft", dec : 0 };
-			}
-			else if (unit=="2")
-			{
-				l_x = { suf : "km", dec : 1 };
-				l_y = { suf : "m", dec : 0 };
-			}
-			else if (unit=="3")
-			{
-				l_x = { suf : "NM", dec : 1 };
-				l_y = { suf : "m", dec : 0 };
-			}
-			else if (unit=="4")
-			{
-				l_x = { suf : "mi", dec : 1 };
-				l_y = { suf : "m", dec : 0 };
-			}
-			else if (unit=="5")
-			{
-				l_x = { suf : "NM", dec : 1 };
-				l_y = { suf : "ft", dec : 0 };
-			}
-			else
-			{
-				l_x = { suf : "m", dec : 0 };
-				l_y = { suf : "m", dec : 0 };
+			if ( unit == "1" ) {
+				l_x = { suf: "mi", dec: 1 };
+				l_y = { suf: "ft", dec: 0 };
+			} else if ( unit == "2" ) {
+				l_x = { suf: "km", dec: 1 };
+				l_y = { suf: "m", dec: 0 };
+			} else if ( unit == "3" ) {
+				l_x = { suf: "NM", dec: 1 };
+				l_y = { suf: "m", dec: 0 };
+			} else if ( unit == "4" ) {
+				l_x = { suf: "mi", dec: 1 };
+				l_y = { suf: "m", dec: 0 };
+			} else if ( unit == "5" ) {
+				l_x = { suf: "NM", dec: 1 };
+				l_y = { suf: "ft", dec: 0 };
+			} else {
+				l_x = { suf: "m", dec: 0 };
+				l_y = { suf: "m", dec: 0 };
 			}
 
 			var nn = 1111.1;
 			var _nn = nn.toLocaleString();
 			var _nnLen = _nn.length;
-			var decPoint = _nn.substring(_nnLen - 2, _nnLen - 1);
-			var thousandsSep = _nn.substring(1, 2);
+			var decPoint = _nn.substring( _nnLen - 2, _nnLen - 1 );
+			var thousandsSep = _nn.substring( 1, 2 );
 
-			if (decPoint == "1")
+			if ( decPoint == "1" )
 				decPoint = ".";
 
-			if (thousandsSep == "1")
+			if ( thousandsSep == "1" )
 				thousandsSep = "";
 
 			// define the options
 			var hoptions = {
 				type: 'line',
 				data: {
-					datasets: [],
+					datasets: []
 				},
 				borderWidth: 1,
 				options: {
@@ -1083,384 +1066,340 @@ var WPGPXMAPS = {
 					},
 					scales: {
 						yAxes: [],
-			            xAxes: [{
-			                type: 'linear',
+						xAxes: [ {
+							type: 'linear',
 							ticks: {
 								suggestedMin: 0,
-								max: graphDist[graphDist.length-1],
+								max: graphDist[graphDist.length - 1],
 								// Include a dollar sign in the ticks
-								callback: function(value, index, values) {
-									return Math.round(value, l_x.dec) + l_x.suf;
+								callback: function( value, index, values ) {
+									return Math.round( value, l_x.dec ) + l_x.suf;
 								}
 							}
-			            }]
+						} ]
 					},
 					tooltips: {
 						position: 'average',
 						mode: 'index',
 						intersect: false,
-						callbacks : {
-							title: function(tooltipItems, data) {
+						callbacks: {
+							title: function( tooltipItems, data ) {
 								//Return value for title
 								var fpt = _formats[0];
-								return Math.round(tooltipItems[0].xLabel, fpt.dec) + fpt.suf;;
+								return Math.round( tooltipItems[0].xLabel, fpt.dec ) + fpt.suf;;
 							},
-							label : function(tooltipItem, data) {
+							label: function( tooltipItem, data ) {
 								// format list values
 								var label = data.datasets[tooltipItem.datasetIndex].label || '';
 								var fpt = _formats[tooltipItem.datasetIndex];
-								if (label) {
+								if ( label ) {
 									label += ': ';
 								}
-								label += Math.round(tooltipItem.yLabel, fpt.dec) + fpt.suf;
+								label += Math.round( tooltipItem.yLabel, fpt.dec ) + fpt.suf;
 								return label;
 							},
-							footer : function(tooltipItem){
+							footer: function( tooltipItem ) {
 								// move the point in map
 								var i = tooltipItem[0].index;
-								var point = WPGPXMAPS.Utils.GetItemFromArray(mapData,i)
-								map.MoveMarkerToPosition(point, false);
+								var point = WPGPXMAPS.Utils.GetItemFromArray( mapData, i )
+								map.MoveMarkerToPosition( point, false );
 
 							}
 						}
-					},
+					}
 				},
 
-				plugins: [{
-					beforeEvent: function(chart, e) {
-						if ((e.type === 'mousemove')
-						&& (e.x >= e.chart.chartArea.left)
-						&& (e.x <= e.chart.chartArea.right)
+				plugins: [ {
+					beforeEvent: function( chart, e ) {
+						if ( ( e.type === 'mousemove' )
+						&& ( e.x >= e.chart.chartArea.left )
+						&& ( e.x <= e.chart.chartArea.right )
 						) {
 							chart.options.customLine.x = e.x;
 						}
 					},
-					afterDraw: function(chart, easing) {
+					afterDraw: function( chart, easing ) {
 						var ctx = chart.chart.ctx;
 						var chartArea = chart.chartArea;
 						var x = chart.options.customLine.x;
-						if (!isNaN(x)) {
+						if ( ! isNaN( x ) ) {
 							ctx.save();
 							ctx.strokeStyle = chart.options.customLine.color;
-							ctx.moveTo(chart.options.customLine.x, chartArea.bottom);
-							ctx.lineTo(chart.options.customLine.x, chartArea.top);
+							ctx.moveTo( chart.options.customLine.x, chartArea.bottom );
+							ctx.lineTo( chart.options.customLine.x, chartArea.top );
 							ctx.stroke();
 							ctx.restore();
 						}
 					}
-				}],
-
-				labels : graphDist,
-
+				} ],
+				labels: graphDist
 			};
 
-			if (graphEle != '')
-			{
+			if ( graphEle != '' ) {
 
-				var myData = mergeArrayForChart(graphDist, graphEle);
+				var myData = mergeArrayForChart( graphDist, graphEle );
 
 				var yaxe = {
 					type: 'linear',
 					ticks: {
 						// Include a dollar sign in the ticks
-						callback: function(value, index, values) {
-							return Math.round(value, l_y.dec) + l_y.suf;
+						callback: function( value, index, values ) {
+							return Math.round( value, l_y.dec ) + l_y.suf;
 						}
 					},
-					id: "y-axis-" + (hoptions.options.scales.yAxes.length + 1),
+					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
-				if ( chartFrom1 != '' )
-				{
+				if ( chartFrom1 != '' )	{
 					yaxe.min = chartFrom1;
 					yaxe.startOnTick = false;
-				}
-				else {
+				} else {
 					yaxe.min = myData.Min;
 				}
-
-				if ( chartTo1 != '' )
-				{
+				if ( chartTo1 != '' ) {
 					yaxe.max = chartTo1;
 					yaxe.endOnTick = false;
-				}
-				else {
+				} else {
 					yaxe.max = myData.Max;
 				}
-				_formats.push(l_y)
-				hoptions.options.scales.yAxes.push(yaxe);
-				hoptions.data.datasets.push( wpgpxmapsGetDataset(lng.altitude, myData.Items, color2, yaxe.id ));
+				_formats.push( l_y )
+				hoptions.options.scales.yAxes.push( yaxe );
+				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.altitude, myData.Items, color2, yaxe.id ) );
 
 			}
 
-			if (graphSpeed != '') {
-				if (unitspeed == '6') /* min/100m */
-				{
-					l_s = { suf : "min/100m", dec : 2 };
-				}
-				else if (unitspeed == '5') /* knots */
-				{
-					l_s = { suf : "knots", dec : 2 };
-				}
-				else if (unitspeed == '4') /* min/miles */
-				{
-					l_s = { suf : "min/mi", dec : 2 };
-				}
-				else if (unitspeed == '3') /* min/km */
-				{
-					l_s = { suf : "min/km", dec : 2 };
-				}
-				else if (unitspeed == '2') /* miles/h */
-				{
-					l_s = { suf : "mi/h", dec : 0 };
-				}
-				else if (unitspeed == '1') /* km/h */
-				{
-					l_s = { suf : "km/h", dec : 0 };
-				}
-				else
-				{
-					l_s = { suf : "m/s", dec : 0 };
+			if ( graphSpeed != '' ) {
+				if ( unitspeed == '6' ) /* min/100m */ {
+					l_s = { suf: "min/100m", dec: 2 };
+				} else if ( unitspeed == '5' ) /* knots */ {
+					l_s = { suf: "knots", dec: 2 };
+				} else if ( unitspeed == '4' ) /* min/miles */ {
+					l_s = { suf: "min/mi", dec: 2 };
+				} else if ( unitspeed == '3' ) /* min/km */ {
+					l_s = { suf: "min/km", dec: 2 };
+				} else if ( unitspeed == '2' ) /* miles/h */ {
+					l_s = { suf: "mi/h", dec: 0 };
+				} else if ( unitspeed == '1' ) /* km/h */ {
+					l_s = { suf: "km/h", dec: 0 };
+				} else {
+					l_s = { suf: "m/s", dec: 0 };
 				}
 
-				var myData = mergeArrayForChart(graphDist, graphSpeed);
+				var myData = mergeArrayForChart( graphDist, graphSpeed );
 
 				var yaxe = {
 					type: 'linear',
 					ticks: {
 						// Include a dollar sign in the ticks
-						callback: function(value, index, values) {
-							return Math.round(value, l_s.dec) + l_s.suf;
+						callback: function( value, index, values ) {
+							return Math.round( value, l_s.dec ) + l_s.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + (hoptions.options.scales.yAxes.length + 1),
+					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
-				if ( chartFrom2 != '' )
-				{
+				if ( chartFrom2 != '' ) {
 					yaxe.min = chartFrom2;
 					yaxe.startOnTick = false;
-				}
-				else {
+				} else {
 					yaxe.min = myData.Min;
 				}
 
-				if ( chartTo2 != '' )
-				{
+				if ( chartTo2 != '' ) {
 					yaxe.max = chartTo2;
 					yaxe.endOnTick = false;
-				}
-				else {
+				} else {
 					yaxe.max = myData.Max;
 				}
 
-
-				_formats.push(l_s);
-				hoptions.options.scales.yAxes.push(yaxe);
-				hoptions.data.datasets.push( wpgpxmapsGetDataset(lng.speed, myData.Items, color3, yaxe.id ) );
+				_formats.push ( l_s );
+				hoptions.options.scales.yAxes.push( yaxe );
+				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.speed, myData.Items, color3, yaxe.id ) );
 
 			}
 
-			if (graphHr != '')
-			{
+			if ( graphHr != '' ) {
 
-				var myData = mergeArrayForChart(graphDist, graphHr);
+				var myData = mergeArrayForChart( graphDist, graphHr );
 
 				var yaxe = {
 					type: 'linear',
 					ticks: {
 						// Include a dollar sign in the ticks
-						callback: function(value, index, values) {
-							return Math.round(value, l_hr.dec) + l_hr.suf;
+						callback: function( value, index, values ) {
+							return Math.round( value, l_hr.dec ) + l_hr.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + (hoptions.options.scales.yAxes.length + 1),
+					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
-				hoptions.options.scales.yAxes.push(yaxe);
-				hoptions.data.datasets.push( wpgpxmapsGetDataset(lng.heartRate, myData.Items, color4, yaxe.id ) );
-				_formats.push(l_hr);
+				hoptions.options.scales.yAxes.push( yaxe );
+				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.heartRate, myData.Items, color4, yaxe.id ) );
+				_formats.push( l_hr );
 			}
 
 
-			if (graphAtemp != '')
-			{
+			if ( graphAtemp != '' ) {
 
-				var myData = mergeArrayForChart(graphDist, graphAtemp);
+				var myData = mergeArrayForChart( graphDist, graphAtemp );
 
 				var yaxe = {
 					type: 'linear',
 					ticks: {
 						// Include a dollar sign in the ticks
-						callback: function(value, index, values) {
-							return Math.round(value, 1) + "°C";
+						callback: function( value, index, values ) {
+							return Math.round( value, 1 ) + "°C";
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + (hoptions.options.scales.yAxes.length + 1),
+					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
-				hoptions.options.scales.yAxes.push(yaxe);
-				hoptions.data.datasets.push( wpgpxmapsGetDataset(lng.atemp, myData.Items, color7, yaxe.id ) );
-				_formats.push({ suf : "°C", dec : 1 });
+				hoptions.options.scales.yAxes.push( yaxe );
+				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.atemp, myData.Items, color7, yaxe.id ) );
+				_formats.push({ suf: "°C", dec: 1 });
 
 			}
 
 
-			if (graphCad != '')
-			{
+			if ( graphCad != '' ) {
 
-				var myData = mergeArrayForChart(graphDist, graphCad, true);
+				var myData = mergeArrayForChart( graphDist, graphCad, true );
 
 				var yaxe = {
 					type: 'linear',
 					ticks: {
 						// Include a dollar sign in the ticks
-						callback: function(value, index, values) {
-							return Math.round(value, l_cad.dec) + l_cad.suf;
+						callback: function( value, index, values ) {
+							return Math.round( value, l_cad.dec ) + l_cad.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + (hoptions.options.scales.yAxes.length + 1),
+					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
-				hoptions.options.scales.yAxes.push(yaxe);
-				hoptions.data.datasets.push( wpgpxmapsGetDataset(lng.cadence, myData.Items, color5, yaxe.id) );
-				_formats.push(l_cad);
+				hoptions.options.scales.yAxes.push( yaxe );
+				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.cadence, myData.Items, color5, yaxe.id ) );
+				_formats.push( l_cad );
 
 			}
 
-			if (graphGrade != '')
-			{
+			if ( graphGrade != '' ) {
 
-				var myData = mergeArrayForChart(graphDist, graphGrade);
+				var myData = mergeArrayForChart( graphDist, graphGrade );
 
 				var yaxe = {
 					type: 'linear',
 					ticks: {
 						// Include a dollar sign in the ticks
-						callback: function(value, index, values) {
-							return Math.round(value, l_grade.dec) + l_grade.suf;
+						callback: function( value, index, values ) {
+							return Math.round( value, l_grade.dec ) + l_grade.suf;
 						}
 					},
 					position: 'right',
 					scalePositionLeft: false,
-					id: "y-axis-" + (hoptions.options.scales.yAxes.length + 1),
+					id: "y-axis-" + ( hoptions.options.scales.yAxes.length + 1 )
 				};
 
-				_formats.push(l_grade);
-				hoptions.options.scales.yAxes.push(yaxe);
-				hoptions.data.datasets.push( wpgpxmapsGetDataset(lng.grade, myData.Items, color6, yaxe.id ) );
+				_formats.push( l_grade );
+				hoptions.options.scales.yAxes.push( yaxe );
+				hoptions.data.datasets.push( wpgpxmapsGetDataset( lng.grade, myData.Items, color6, yaxe.id ) );
 
 			}
 
-			var ctx = document.getElementById("myChart_" + params.targetId).getContext('2d');
-			var myChart = new Chart(ctx, hoptions);
+			var ctx = document.getElementById( "myChart_" + params.targetId ).getContext( '2d' );
+			var myChart = new Chart( ctx, hoptions );
 
-		}
-		else  {
-			jQuery("#myChart_" + params.targetId).css("display","none");
+		} else  {
+			jQuery( "#myChart_" + params.targetId ).css( "display", "none" );
 		}
 
         return this;
     };
 
-	function mergeArrayForChart(distArr, dataArr, setZerosAsNull)
-	{
+	function mergeArrayForChart( distArr, dataArr, setZerosAsNull ) {
 		var l = distArr.length;
 
-		var items = new Array(l);
-		var min=10000;
-		var max=-10000;
+		var items = new Array( l );
+		var min = 10000;
+		var max = -10000;
 
-		for (i=0; i<l; i++)
-		{
-			if (distArr[i] != null)
-			{
+		for ( i = 0; i < l; i++ ) {
+			if ( distArr[i] != null ) {
 				var _item = dataArr[i];
 
-				if (setZerosAsNull === true && _item === 0)
-				{
+				if ( setZerosAsNull === true && _item === 0 ) {
 					_item = null;
 				}
 
 				items[i] = {
-								x: distArr[i],
-								y:_item
-							};
-				if (_item > max)
+					x: distArr[i],
+					y: _item
+				};
+				if ( _item > max )
 					max = _item;
-				if (_item < min)
+				if ( _item < min )
 					min = _item;
 			}
 		}
-
 		return {
-			Items : items,
-			Min : min,
-			Max : max,
+			Items: items,
+			Min: min,
+			Max: max
 		}
-
 	}
 
-	function wpgpxmapsGetDataset(name,data,color, id) {
+	function wpgpxmapsGetDataset( name, data, color, id ) {
 		return {
 			label: name, // jQuery("<div/>").html(name).text(), // convert html special chars to text, ugly but it works
-			data : data,
+			data: data,
 			borderColor: color,
-			backgroundColor: hexToRgbA(color, .3),
+			backgroundColor: hexToRgbA( color, .3 ),
 			pointRadius: 0,
 			borderWidth: 1,
 			pointHoverRadius: 1,
-			yAxisID: id,
+			yAxisID: id
 		}
 	}
 
-	function hexToRgbA(hex,a){
+	function hexToRgbA( hex, a ) {
 		var c;
-		if(/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)){
-			c= hex.substring(1).split('');
-			if(c.length== 3){
-				c= [c[0], c[0], c[1], c[1], c[2], c[2]];
+		if ( /^#([A-Fa-f0-9]{3}){1,2}$/.test( hex ) ) {
+			c = hex.substring( 1 ).split( '' );
+			if ( c.length == 3 ) {
+				c = [ c[0], c[0], c[1], c[1], c[2], c[2] ];
 			}
-			c= '0x'+c.join('');
-			return 'rgba('+[(c>>16)&255, (c>>8)&255, c&255].join(',')+',' + a +')';
+			c = '0x' + c.join( '' );
+			return 'rgba(' + [ ( c>>16 )&255, ( c>>8)&255, c&255 ].join( ',' ) + ',' + a + ' )';
 		}
-		throw new Error('Bad Hex');
+		throw new Error( 'Bad Hex' );
 	}
 
 
-	function getItemFromArray(arr,index)
-	{
-		try
-		{
-		  return arr[index];
-		}
-		catch(e)
-		{
-			return [0,0];
+	function getItemFromArray( arr, index ) {
+		try {
+			return arr[index];
+		} catch ( e ) {
+			return [ 0, 0 ];
 		}
 	}
 
 
-	function getClosestIndex(points,lat,lon)
-	{
-		var dd=10000;
-		var ii=0;
-		for (i=0; i < points.length; i++)
-		{
-			if (points[i]==null)
+	function getClosestIndex( points, lat, lon ) {
+		var dd = 10000;
+		var ii = 0;
+		for ( i = 0; i < points.length; i++ ) {
+			if ( points[i] == null )
 				continue;
 
-			var d = wpgpxmapsDist(points[i][0], points[i][1], lat, lon);
-			if ( d < dd )
-			{
+			var d = wpgpxmapsDist( points[i][0], points[i][1], lat, lon );
+			if ( d < dd ) {
 				ii = i;
 				dd = d;
 			}
@@ -1468,22 +1407,20 @@ var WPGPXMAPS = {
 		return ii;
 	}
 
-	function getClosestImage(lat,lon,targetId)
-	{
-		var dd=10000;
+	function getClosestImage( lat, lon, targetId ) {
+		var dd = 10000;
 		var img;
-		var divImages = document.getElementById("ngimages_"+targetId);
-		var img_spans = divImages.getElementsByTagName("span");
-		for (var i = 0; i < img_spans.length; i++) {
-			var imageLat = img_spans[i].getAttribute("lat");
-			var imageLon = img_spans[i].getAttribute("lon");
+		var divImages = document.getElementById( "ngimages_" + targetId );
+		var img_spans = divImages.getElementsByTagName( "span" );
+		for ( var i = 0; i < img_spans.length; i++ ) {
+			var imageLat = img_spans[i].getAttribute( "lat" );
+			var imageLon = img_spans[i].getAttribute( "lon" );
 
-			imageLat = imageLat.replace(",", ".");
-			imageLon = imageLon.replace(",", ".");
+			imageLat = imageLat.replace( ",", "." );
+			imageLon = imageLon.replace( ",", "." );
 
-			var d = wpgpxmapsDist(imageLat, imageLon, lat, lon);
-			if ( d < dd )
-			{
+			var d = wpgpxmapsDist( imageLat, imageLon, lat, lon );
+			if ( d < dd ) {
 				img = img_spans[i];
 				dd = d;
 			}
@@ -1491,17 +1428,16 @@ var WPGPXMAPS = {
 		return img;
 	}
 
-	function isNumeric(input){
+	function isNumeric( input ) {
 		var RE = /^-{0,1}\d*\.{0,1}\d+$/;
-		return (RE.test(input));
+		return ( RE.test( input ) );
 	}
 
-	function wpgpxmapsDist(lat1,lon1,lat2,lon2)
-	{
+	function wpgpxmapsDist( lat1, lon1, lat2, lon2 ) {
 		// mathematically not correct but fast
-		var dLat = (lat2-lat1);
-		var dLon = (lon2-lon1);
-		return Math.sqrt(dLat * dLat + dLon * dLon);
+		var dLat = ( lat2 - lat1 );
+		var dLon = ( lon2 - lon1 );
+		return Math.sqrt( dLat * dLat + dLon * dLon );
 	}
 
-}( jQuery ));
+}( jQuery ) );

--- a/readme.txt
+++ b/readme.txt
@@ -172,7 +172,10 @@ Yes!
 
 == Changelog ==
 
-= X.X.XX
+= X.X.XX =
+* Fixed: In Settings and Help the maps provider changed from open cycle map to Thunderforest
+* Fixed: If Thunderforest API key is entered, Thunderforest maps can be selected in the output instead of Open Cycle Map maps
+* Fixed: in map footer is now the correct URL from the map provider
 * Added: PHP version notices, WordPress 5.3 requires PHP 5.6.20
 * Added: Missing entries for add and delete options
 * Changed: Style for output moved in a seperate file

--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -12,7 +12,7 @@
  * @package WP-GPX-Maps
  */
 
-//error_reporting (E_ALL);
+// error_reporting (E_ALL);
 
 require 'wp-gpx-maps_utils.php';
 require 'wp-gpx-maps_admin.php';
@@ -156,7 +156,7 @@ function handle_WP_GPX_Maps_folder_Shortcodes( $attr, $content = '' ) {
 
 		if ( strtolower( substr( $file, - 4 ) ) == '.gpx' ) {
 
-			$gpx = $folder . DIRECTORY_SEPARATOR . $file;
+			$gpx    = $folder . DIRECTORY_SEPARATOR . $file;
 			$points = wpgpxmaps_getPoints( $gpx, $pointsoffset, $donotreducegpx, $distanceType );
 
 			$points_maps       = '';
@@ -440,7 +440,7 @@ function handle_WP_GPX_Maps_Shortcodes( $attr, $content = '' ) {
 				if ( $uom == '1') {
 					/* feet / miles */
 					$_dist *= 0.000621371192;
-					$_ele *= 3.2808399;
+					$_ele  *= 3.2808399;
 
 				} elseif ( $uom == '2') {
 					/* meters / kilometers */
@@ -743,7 +743,7 @@ function handle_WP_GPX_Maps_Shortcodes( $attr, $content = '' ) {
 		}
 		if ( $p_total_time == true && $max_time > 0 ) {
 			$time_diff = date( 'H:i:s', ( $max_time - $min_time ) );
-			$output .= "<span class='totaltime'><span class='summarylabel'>" . __( 'Total time:', 'wp-gpx-maps' ) . "</span><span class='summaryvalue'> $time_diff</span></span><br />";
+			$output   .= "<span class='totaltime'><span class='summarylabel'>" . __( 'Total time:', 'wp-gpx-maps' ) . "</span><span class='summaryvalue'> $time_diff</span></span><br />";
 		}
 		$output .= '</div>';
 	}

--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -789,7 +789,7 @@ function convertSpeed( $speed, $uomspeed, $addUom = false ) {
 		$uom    = ' knots';
 
 	} elseif ( $uomspeed == '4' ) {
-		/* min/mi */
+		/* min/miles*/
 		$speed = convertSeconds( $speed * 0.037282272 );
 		$uom   = ' min/mi';
 

--- a/wp-gpx-maps_admin_settings.php
+++ b/wp-gpx-maps_admin_settings.php
@@ -350,19 +350,19 @@
 						<input type="radio" name="wpgpxmaps_map_type" value="OSM2" <?php if ( $t == 'OSM2' ) echo 'checked'; ?>>
 							<?php
 							/* translators: map provider / map type */
-							_e( 'Open Cycle Map', 'wp-gpx-maps' );
+							_e( 'Thunderforest - Open Cycle Map (API Key required)', 'wp-gpx-maps' );
 							?>
 						<br />
 						<input type="radio" name="wpgpxmaps_map_type" value="OSM4" <?php if ( $t == 'OSM4' ) echo 'checked'; ?>>
 							<?php
 							/* translators: map provider / map type */
-							_e( 'Open Cycle Map - Transport', 'wp-gpx-maps' );
+							_e( 'Thunderforest - Transport (API Key required)', 'wp-gpx-maps' );
 							?>
 						<br />
 						<input type="radio" name="wpgpxmaps_map_type" value="OSM5" <?php if ( $t == 'OSM5' ) echo 'checked'; ?>>
 							<?php
 							/* translators: map provider / map type */
-							_e( 'Open Cycle Map - Landscape', 'wp-gpx-maps' );
+							_e( 'Thunderforest - Landscape (API Key required)', 'wp-gpx-maps' );
 							?>
 						<br />
 						<input type="radio" name="wpgpxmaps_map_type" value="OSM6" <?php if ( $t == 'OSM6' ) echo 'checked'; ?>>

--- a/wp-gpx-maps_help.php
+++ b/wp-gpx-maps_help.php
@@ -230,17 +230,17 @@
 						<br />
 						<?php
 						/* translators: selection = map provider / map type */
-						_e( 'OSM2 = Open Cycle Map', 'wp-gpx-maps' );
+						_e( 'OSM2 = Thunderforest - Open Cycle Map (API Key required)', 'wp-gpx-maps' );
 						?>
 						<br />
 						<?php
 						/* translators: selection = map provider / map type */
-						_e( 'OSM4 = Open Cycle Map - Transport', 'wp-gpx-maps' );
+						_e( 'OSM4 = Thunderforest - Transport (API Key required)', 'wp-gpx-maps' );
 						?>
 						<br />
 						<?php
 						/* translators: selection = map provider / map type */
-						_e( 'OSM5 = Open Cycle Map - Landscape', 'wp-gpx-maps' );
+						_e( 'OSM5 = Thunderforest - Landscape (API Key required)', 'wp-gpx-maps' );
 						?>
 						<br />
 						<?php

--- a/wp-gpx-maps_utils.php
+++ b/wp-gpx-maps_utils.php
@@ -18,8 +18,7 @@ function wpgpxmaps_getAttachedImages( $dt, $lat, $lon, $dtoffset, &$error ) {
 			'post_mime_type' => 'image',
 			'order'          => 'ASC',
 			'orderby'        => 'menu_order ASC',
-			)
-		);
+		) );
 
 		foreach ( $attachments as $attachment_id => $attachment ) {
 
@@ -27,7 +26,7 @@ function wpgpxmaps_getAttachedImages( $dt, $lat, $lon, $dtoffset, &$error ) {
 			$img_thmb     = wp_get_attachment_image_src( $attachment_id, 'thumbnail' );
 			$img_metadata = wp_get_attachment_metadata( $attachment_id );
 
-			$item = array();
+			$item         = array();
 			$item['data'] = wp_get_attachment_link( $attachment_id, array( 105, 105 ) );
 
 			if ( is_callable( 'exif_read_data' ) ) {
@@ -43,7 +42,7 @@ function wpgpxmaps_getAttachedImages( $dt, $lat, $lon, $dtoffset, &$error ) {
 						if ( $_item != null ) {
 							$item['lat'] = $_item['lat'];
 							$item['lon'] = $_item['lon'];
-							$result[] = $item;
+							$result[]    = $item;
 						}
 					}
 				}
@@ -69,10 +68,9 @@ function gpxFolderPath() {
 	$upload_dir  = wp_upload_dir();
 	$uploadsPath = $upload_dir['basedir'];
 
-	if ( current_user_can( 'manage_options' ) ){
+	if ( current_user_can( 'manage_options' ) ) {
 			$ret = $uploadsPath . DIRECTORY_SEPARATOR . 'gpx';
-	}
-	elseif ( current_user_can( 'publish_posts' ) ) {
+	} elseif ( current_user_can( 'publish_posts' ) ) {
 			global $current_user;
 			wp_get_current_user();
 			$ret = $uploadsPath . DIRECTORY_SEPARATOR . 'gpx' . DIRECTORY_SEPARATOR . $current_user->user_login;
@@ -225,11 +223,11 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 
 			$trkpts = $trk->xpath( '//trkpt | //a:trkpt | //b:trkpt' );
 
-			$lastLat     = 0;
-			$lastLon     = 0;
-			$lastEle     = 0;
-			$lastTime    = 0;
-			//$dist      = 0;
+			$lastLat  = 0;
+			$lastLon  = 0;
+			$lastEle  = 0;
+			$lastTime = 0;
+			// $dist = 0;
 			$lastOffset  = 0;
 			$speedBuffer = array();
 
@@ -251,14 +249,15 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 
 					if ( isset( $arr['ns3:TrackPointExtension'] ) ) {
 						$tpe   = $arr['ns3:TrackPointExtension'];
-						$hr    = @$tpe["ns3:hr"];
-						$atemp = @$tpe["ns3:atemp"];
-						$cad   = @$tpe["ns3:cad"];
+						$hr    = @$tpe['ns3:hr'];
+						$atemp = @$tpe['ns3:atemp'];
+						$cad   = @$tpe['ns3:cad'];
+
 					} elseif ( isset( $arr['TrackPointExtension'] ) ) {
 						$tpe   = $arr['TrackPointExtension'];
-						$hr    = @$tpe["hr"];
-						$atemp = @$tpe["atemp"];
-						$cad   = @$tpe["cad"];
+						$hr    = @$tpe['hr'];
+						$atemp = @$tpe['atemp'];
+						$cad   = @$tpe['cad'];
 					}
 				}
 
@@ -284,7 +283,7 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 
 					/* Normal Case  */
 					$offset = calculateDistance( (float) $lat, (float) $lon, (float) $ele, (float) $lastLat, (float) $lastLon, (float) $lastEle, $distancetype );
-					$dist = $dist + $offset;
+					$dist   = $dist + $offset;
 
 					$points->totalLength = $dist;
 
@@ -393,7 +392,7 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 			$_temp           = array_filter( $points->atemp );
 			$points->avgTemp = (float) round( array_sum( $_temp ) / count( $_temp ), 1 );
 
-			} catch ( Exception $e ) {
+		} catch ( Exception $e ) {
 		}
 	} else {
 
@@ -493,7 +492,7 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 
 						/* Normal Case */
 						$offset = calculateDistance( $lat, $lon, 0, $lastLat, $lastLon, 0, $distancetype );
-						$dist = $dist + $offset;
+						$dist   = $dist + $offset;
 						if ( ( (float) $offset + (float) $lastOffset ) > $gpxOffset ) {
 
 							/* Bigger Offset -> write coordinate */
@@ -510,7 +509,7 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 						} else {
 
 							/* Smoller Offset -> continue.. */
-							$lastOffset= (float) $lastOffset + (float) $offset;
+							$lastOffset = (float) $lastOffset + (float) $offset;
 						}
 					}
 					$lastLat = $lat;
@@ -583,7 +582,7 @@ function toRadians( $degrees ) {
 		return (float) ( $degrees * 3.1415926535897932385 / 180 );
 }
 
-function calculateDistance ( $lat1, $lon1, $ele1, $lat2, $lon2, $ele2, $distancetype ) {
+function calculateDistance( $lat1, $lon1, $ele1, $lat2, $lon2, $ele2, $distancetype ) {
 
 		/* Distance typ: Climb */
 	if ( $distancetype == '2' ) {

--- a/wp-gpx-maps_utils_nggallery.php
+++ b/wp-gpx-maps_utils_nggallery.php
@@ -49,7 +49,7 @@ function getNGGalleryImages( $ngGalleries, $ngImages, $dt, $lat, $lon, $dtoffset
 						if ( $_item != null ) {
 							$item['lat'] = $_item['lat'];
 							$item['lon'] = $_item['lon'];
-							$result[] = $item;
+							$result[]    = $item;
 						}
 					}
 				}


### PR DESCRIPTION
* Fixed: In Settings and Help the maps provider changed from open cycle map to Thunderforest
* Fixed: If Thunderforest API key is entered, Thunderforest maps can be selected in the output instead of    Open Cycle Map maps
* Fixed: in map footer is now the correct URL from the map provider

Many WPCS messages in WP-GPX-Maps.js reduced from over 1000 to 234:
-all messages because blank space
- added missing semicolons
- removes superfluous commas
- many double quotes exchanged for single quotes
- some yoda checks
- added code comments