### PR TITLE
Update download link name to display gpx file name

### DIFF
--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -767,7 +767,8 @@ function wpgpxmaps_handle_shortcodes( $attr, $content = '' ) {
 			$dummy  = ( defined( 'WP_SITEURL' ) ) ? WP_SITEURL : get_bloginfo( 'url' );
 			$gpxurl = $dummy . $gpxurl;
 		}
-		$output .= "<a href='$gpxurl' target='_new' download>" . __( 'Download', 'wp-gpx-maps' ) . '</a>';
+		$downloadname = basename($gpxurl);
+		$output .= "Download file: <a href='$gpxurl' target='_new' download>" . __( $downloadname, 'wp-gpx-maps' ) . '</a>';
 	}
 
 	return $output;


### PR DESCRIPTION
I think the current behavior of printing an anchor tag with text "Download" is a little ambiguous for content consumers. This pull request proposes updating the text to print the name of the gpx file linked to.

Link "example.com/wp-content/uploads/gpx/Filename.gpx" will now create link:

> Download file: Filename.gpx
