### PR TITLE
Provide options for GPX metadata to be displayed with the map

### DIFF
--- a/wp-gpx-maps-admin-settings.php
+++ b/wp-gpx-maps-admin-settings.php
@@ -27,6 +27,8 @@ $avg_cad        = get_option( 'wpgpxmaps_summary_avg_cad' );
 $avg_hr         = get_option( 'wpgpxmaps_summary_avg_hr' );
 $avg_temp       = get_option( 'wpgpxmaps_summary_avg_temp' );
 $total_time     = get_option( 'wpgpxmaps_summary_total_time' );
+$showName 		= get_option( 'wpgpxmaps_summary_show_name' );
+$showDesc 		= get_option( 'wpgpxmaps_summary_show_desc' );
 /* Map */
 $t                 = get_option( 'wpgpxmaps_map_type' );
 $zoomonscrollwheel = get_option( 'wpgpxmaps_zoomonscrollwheel' );
@@ -309,11 +311,35 @@ if ( ! ( $po ) )
 					</td>
 				</tr>
 
+				<tr>
+					<th scope="row">
+						<?php esc_html_e( 'Show name:', 'wp-gpx-maps' ); ?>
+					</th>
+					<td>
+						<input name="wpgpxmaps_summary_show_name" type="checkbox" value="true" <?php if ( true == $showName ) { echo ( 'checked' ); } ?> onchange="this.value = (this.checked)" />
+						<i>
+							<?php esc_html_e( 'Show name from GPX metadata', 'wp-gpx-maps' ); ?>
+						</i>
+					</td>
+				</tr>
+
+								<tr>
+					<th scope="row">
+						<?php esc_html_e( 'Show description:', 'wp-gpx-maps' ); ?>
+					</th>
+					<td>
+						<input name="wpgpxmaps_summary_show_desc" type="checkbox" value="true" <?php if ( true == $showDesc ) { echo ( 'checked' ); } ?> onchange="this.value = (this.checked)" />
+						<i>
+							<?php esc_html_e( 'Show description from GPX metadata', 'wp-gpx-maps' ); ?>
+						</i>
+					</td>
+				</tr>
+
 			</table>
 
 			<p class="submit">
 				<input type="hidden" name="action" value="update" />
-				<input name="page_options" type="hidden" value="wpgpxmaps_summary,wpgpxmaps_summary_tot_len,wpgpxmaps_summary_max_ele,wpgpxmaps_summary_min_ele,wpgpxmaps_summary_total_ele_up,wpgpxmaps_summary_total_ele_down,wpgpxmaps_summary_avg_speed,wpgpxmaps_summary_avg_cad,wpgpxmaps_summary_avg_hr,wpgpxmaps_summary_avg_temp,wpgpxmaps_summary_total_time" />
+				<input name="page_options" type="hidden" value="wpgpxmaps_summary,wpgpxmaps_summary_tot_len,wpgpxmaps_summary_max_ele,wpgpxmaps_summary_min_ele,wpgpxmaps_summary_total_ele_up,wpgpxmaps_summary_total_ele_down,wpgpxmaps_summary_avg_speed,wpgpxmaps_summary_avg_cad,wpgpxmaps_summary_avg_hr,wpgpxmaps_summary_avg_temp,wpgpxmaps_summary_total_time,wpgpxmaps_summary_show_name,wpgpxmaps_summary_show_desc" />
 				<input type="submit" class="button-primary" value="<?php esc_html_e( 'Save Changes', 'wp-gpx-maps' ); ?>" />
 			</p>
 

--- a/wp-gpx-maps-utils.php
+++ b/wp-gpx-maps-utils.php
@@ -204,6 +204,9 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 	$points->avgTemp      = 0;
 	$points->totalLength  = 0;
 
+	$points->name = "";
+	$points->desc = "";
+
 	$gpx = simplexml_load_file( $filePath );
 
 	if ( false === $gpx )
@@ -212,6 +215,9 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 		$gpx->registerXPathNamespace( 'a', 'http://www.topografix.com/GPX/1/0' );
 		$gpx->registerXPathNamespace( 'b', 'http://www.topografix.com/GPX/1/1' );
 		$gpx->registerXPathNamespace( 'ns3', 'http://www.garmin.com/xmlschemas/TrackPointExtension/v1' );
+
+		if (!empty($gpx->metadata->name)) $points->name = $gpx->metadata->name;
+		if (!empty($gpx->metadata->desc)) $points->desc = $gpx->metadata->desc;
 
 		$nodes = $gpx->xpath( '//trk | //a:trk | //b:trk ' );
 		/* Normal GPX */

--- a/wp-gpx-maps.php
+++ b/wp-gpx-maps.php
@@ -247,6 +247,8 @@ function wpgpxmaps_handle_shortcodes( $attr, $content = '' ) {
 	$p_avg_hr         = wpgpxmaps_findValue( $attr, 'summaryavghr', 'wpgpxmaps_summary_avg_hr', false );
 	$p_avg_temp       = wpgpxmaps_findValue( $attr, 'summaryavgtemp', 'wpgpxmaps_summary_avg_temp', false );
 	$p_total_time     = wpgpxmaps_findValue( $attr, 'summarytotaltime', 'wpgpxmaps_summary_total_time', false );
+	$p_show_name	  = wpgpxmaps_findValue( $attr, 'showname', 'wpgpxmaps_summary_show_name', false );
+	$p_show_desc      = wpgpxmaps_findValue( $attr, 'showdesc', 'wpgpxmaps_summary_show_desc', false );
 	/* Map */
 	$mt                 = wpgpxmaps_findValue( $attr, 'mtype', 'wpgpxmaps_map_type', 'HYBRID' );
 	$color_map          = wpgpxmaps_findValue( $attr, 'mlinecolor', 'wpgpxmaps_map_line_color', '#3366cc' );
@@ -389,6 +391,9 @@ function wpgpxmaps_handle_shortcodes( $attr, $content = '' ) {
 		}
 
 		$points = wpgpxmaps_getPoints( $gpx, $pointsoffset, $donotreducegpx, $distanceType );
+
+		$name = $points->name;
+		$desc  = $points->desc;
 
 		$points_maps        = '';
 		$points_graph_dist  = '';
@@ -726,6 +731,10 @@ function wpgpxmaps_handle_shortcodes( $attr, $content = '' ) {
 	if ( true == $summary && ( $points_graph_speed != '' || $points_graph_ele != '' || $points_graph_dist != '' ) ) {
 
 		$output .= "<div id='wpgpxmaps_summary_" . $r . "' class='wpgpxmaps_summary'>";
+		if (true == $p_show_name && $name != '')
+		$output .= "<span class='name'><span class='summarylabel'>" .__('Name:', 'wp-gpx-maps'). "</span><span class='summaryvalue'> $name</span></span><br />";
+		if (true == $p_show_desc && $desc != '')
+		$output .= "<span class='desc'><span class='summarylabel'>" .__('Description:', 'wp-gpx-maps'). "</span><span class='summaryvalue'> $desc</span></span><br />";
 		if ( $points_graph_dist != '' && true == $p_tot_len ) {
 			$output .= "<span class='totlen'><span class='summarylabel'>" . __( 'Total distance:', 'wp-gpx-maps' ) . "</span><span class='summaryvalue'> $tot_len</span></span><br />";
 		}
@@ -963,6 +972,8 @@ function wpgpxmaps_remove_option() {
 	delete_option( 'wpgpxmaps_summary_avg_hr' );
 	delete_option( 'wpgpxmaps_summary_avg_temp' );
 	delete_option( 'wpgpxmaps_summary_total_time' );
+	delete_option( 'wpgpxmaps_summary_show_name' );
+	delete_option( 'wpgpxmaps_summary_show_desc' );
 	/* Map */
 	delete_option( 'wpgpxmaps_map_type' );
 	delete_option( 'wpgpxmaps_map_line_color' );


### PR DESCRIPTION
This change provides the user with two additional options to allow the name and desc metadata to be displayed under the map in the summary section (defaults - do not display).

I've performed a few tests -

- If the user has selected to display the metadata but it does not exist, I've chosen not to print any output (rather than show an empty field in the output).
- It doesn't appear possible for HTML tags etc to survive from the metadata and reach page content. I think that's good!