### PR TITLE
Use _getPoints() to display meta-data in the admin page

### DIFF
--- a/wp-gpx-maps-admin-tracks.php
+++ b/wp-gpx-maps-admin-tracks.php
@@ -148,13 +148,16 @@ if ( is_readable( $realGpxPath ) && $handle = opendir( $realGpxPath ) ) {
 
 				}
 			} else {
-
+				/* Use getPoints to parse the GPX data and extract the <name> field */
+				$points = wpgpxmaps_getPoints($realGpxPath . '/' . $entry,0,0,0);
+				$name = $points->name;
 				$myFile           = $realGpxPath . '/' . $entry;
 				$myGpxFileNames[] = array(
-					'name'     => $entry,
+					'filename'     => $entry,
+					'metadata'	   => "$name",
 					'size'     => filesize( $myFile ),
 					'lastedit' => filemtime( $myFile ),
-					'nonce'    => wp_create_nonce( 'wpgpx_deletefile_nonce_' . $entry ),
+					'nonce' 	   => wp_create_nonce( 'wpgpx_deletefile_nonce_' . $entry ),
 				);
 			}
 		}
@@ -186,20 +189,27 @@ if ( is_readable( $realGpxPath ) && $handle = opendir( $realGpxPath ) ) {
 
 		jQuery('#table').bootstrapTable({
 			columns: [{
-				field: 'name',
+				field: 'filename',
 				title: '<?php _e( 'File', 'wp-gpx-maps' ); ?>',
 				sortable: true,
 				formatter: function(value, row, index) {
 
 					return [
-						'<b>' + row.name + '</b><br />',
+						'<b>' + row.filename + '</b><br />',
 						'<a class="delete_gpx_row" href="<?php echo $wpgpxmapsUrl; ?>&_wpnonce=' + row.nonce + '" ><?php esc_html_e( 'Delete', 'wp-gpx-maps' ); ?></a>',
 						' | ',
-						'<a href="<?php echo $relativeGpxPath; ?>' + row.name + '"><?php esc_html_e( 'Download', 'wp-gpx-maps' ); ?></a>',
+						'<a href="<?php echo $relativeGpxPath; ?>' + row.filename + '"><?php esc_html_e( 'Download', 'wp-gpx-maps' ); ?></a>',
 						' | ',
-						'<a href="#" class="copy-shortcode" title="<?php esc_html_e( 'Copy shortcode', 'wp-gpx-maps' ); ?>"><?php esc_html_e( 'Shortcode:', 'wp-gpx-maps' ); ?></a> <span class="code"> [sgpx gpx="<?php echo $relativeGpxPath; ?>' + row.name + '"]</span>',
+						'<a href="#" class="copy-shortcode" title="<?php esc_html_e( 'Copy shortcode', 'wp-gpx-maps' ); ?>"><?php esc_html_e( 'Shortcode:', 'wp-gpx-maps' ); ?></a> <span class="code"> [sgpx gpx="<?php echo $relativeGpxPath; ?>' + row.filename + '"]</span>',
 					].join('')
 
+				}
+			}, {
+				field: 'metadata',
+				title: '<?php esc_html_e( 'Meta-data title', 'wp-gpx-maps' ); ?>',
+				sortable: true,
+				formatter: function(value, row, index) {
+					return '<b>' + row.metadata +'</b>';
 				}
 			}, {
 				field: 'lastedit',


### PR DESCRIPTION
Display the meta-data in the admin page. This can make it easier to sort through a long list of GPX files with similar names.

I had to rename the 'name' field to 'filename' as this was easy to confuse with the <name> field extracted from the GPX file.

I'm not sure if this has a performance impact - it has to load and parse all the GPX files. I don't know if this becomes an issue if you've got 100's of files imported? Let me know if so, and I'll think of a fix (extract field on upload?).