### PR TITLE
attachment-fix

### DIFF
--- a/js/WP-GPX-Maps.js
+++ b/js/WP-GPX-Maps.js
@@ -880,9 +880,9 @@ var WPGPXMAPS = {
 				photos.push({
 					'lat': pos[0],
 					'lng': pos[1],
-					'name': ngg_span_a.getAttribute( 'data-title' ),
-					'url': ngg_span_a.getAttribute( 'data-src' ),
-					'thumbnail': ngg_span_a.getAttribute( 'data-thumbnail' )
+					'name': ngg_span_a.children[0].getAttribute( 'title' ),
+					'url': ngg_span_a.children[0].getAttribute( 'src' ),
+					'thumbnail': ngg_span_a.children[0].getAttribute( 'src' )
 				});
 
 			}

--- a/wp-gpx-maps-utils.php
+++ b/wp-gpx-maps-utils.php
@@ -25,6 +25,7 @@ function wpgpxmaps_getAttachedImages( $dt, $lat, $lon, $dtoffset, &$error ) {
 			$img_src      = wp_get_attachment_image_src( $attachment_id, 'full' );
 			$img_thmb     = wp_get_attachment_image_src( $attachment_id, 'thumbnail' );
 			$img_metadata = wp_get_attachment_metadata( $attachment_id );
+			$img_file     = get_attached_file( $attachment_id, $unfiltered );
 
 			$item         = array();
 			$item['data'] = wp_get_attachment_link( $attachment_id, array( 105, 105 ) );
@@ -42,8 +43,8 @@ function wpgpxmaps_getAttachedImages( $dt, $lat, $lon, $dtoffset, &$error ) {
 					$item['lat'] = getExifGps( $exif['GPSLatitude'], $exif['GPSLatitudeRef'] );
 					if ( ( $item['lat'] != 0 ) || ( $item['lon'] != 0 ) ) {
 						$result[] = $item;
-					} elseif ( isset( $p->imagedate ) ) {
-						$_dt   = strtotime( $p->imagedate ) + $dtoffset;
+					} elseif ( isset( $exif['DateTimeOriginal'] ) ) {
+						$_dt   = strtotime( $exif['DateTimeOriginal'] ) + $dtoffset;
 						$_item = findItemCoordinate( $_dt, $dt, $lat, $lon );
 						if ( $_item != null ) {
 							$item['lat'] = $_item['lat'];

--- a/wp-gpx-maps-utils.php
+++ b/wp-gpx-maps-utils.php
@@ -33,7 +33,7 @@ function wpgpxmaps_getAttachedImages( $dt, $lat, $lon, $dtoffset, &$error ) {
 			if ( is_callable( 'exif_read_data' ) ) {
 				
 				try {
-					$exif = @exif_read_data( $img_src[0] );
+					$exif = @exif_read_data( $img_file );
 				} catch (Exception $e) {
 					$exif = false;
 				}


### PR DESCRIPTION
Fixes issues with photo attachments that are not in NGG, specifically fixing ngg_span_a to use children properly, and to replace the $p-> reference that doesn't exist replacing with original date/time exif data. Also adds reference to the file which exposes the exif data.