### PR TITLE
Improve resilience for GPX files with missing elevation information

### DIFF
--- a/wp-gpx-maps-utils.php
+++ b/wp-gpx-maps-utils.php
@@ -385,8 +385,15 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 			$_time               = array_filter( $points->dt );
 			$_ele                = array_filter( $points->ele );
 			$_dist               = array_filter( $points->dist );
-			$points->maxEle      = max( $_ele );
-			$points->minEle      = min( $_ele );
+
+			if ($_ele) {
+				/* There might be cases where ele is not set in the gpx (0.00).
+					array_filter will filter out those values and as a consequence 
+					min()/max() will fail  */
+				$points->maxEle      = max( $_ele );
+				$points->minEle      = min( $_ele );
+			}
+
 			$points->totalLength = max( $_dist );
 			$points->maxTime     = max( $_time );
 			$points->minTime     = min( $_time );

--- a/wp-gpx-maps-utils.php
+++ b/wp-gpx-maps-utils.php
@@ -387,9 +387,10 @@ function wpgpxmaps_parseXml( $filePath, $gpxOffset, $distancetype ) {
 			$_dist               = array_filter( $points->dist );
 
 			if ($_ele) {
-				/* There might be cases where ele is not set in the gpx (0.00).
-					array_filter will filter out those values and as a consequence 
-					min()/max() will fail  */
+				/* 	
+					There might be cases where ele is not set in the gpx (0.00).
+					array_filter will filter out those values and as a consequence min()/max() would fail. 
+				*/
 				$points->maxEle      = max( $_ele );
 				$points->minEle      = min( $_ele );
 			}


### PR DESCRIPTION
The plugin crashes for GPX files where all trackpoints look like this:
````
<ele>0.00</ele>
````

The reason is that `max()/min()` is called on an empty `array`.
I added the necessary validation.
